### PR TITLE
fix: prevent control-flow false matches in _find_function_bounds

### DIFF
--- a/src/vuln_hunter_x/context/extractor.py
+++ b/src/vuln_hunter_x/context/extractor.py
@@ -53,8 +53,9 @@ class ContextExtractor:
         ],
     }
 
-    def __init__(self, repos_base: Path):
+    def __init__(self, repos_base: Path, output_dir: Path | None = None):
         self.repos_base = Path(repos_base)
+        self.output_dir = Path(output_dir) if output_dir is not None else None
         self._file_cache: dict[str, list[str]] = {}
         self._path_cache: dict[tuple[str, str], Path | None] = {}
 
@@ -69,6 +70,7 @@ class ContextExtractor:
         line: int,
         lang: str,
         context_lines: int = 50,
+        repo_name: str = "",
     ) -> CodeContext:
         """
         Extract function context around the given line.
@@ -78,6 +80,7 @@ class ContextExtractor:
             line: Line number of the finding
             lang: Programming language
             context_lines: Fallback context size
+            repo_name: Repository name (used for CSV lookup)
 
         Returns:
             CodeContext with the extracted code
@@ -94,7 +97,9 @@ class ContextExtractor:
         func_start, func_end, func_name = self._find_function_bounds(
             lines,
             line - 1,
-            lang,  # 0-indexed
+            lang,
+            repo_name=repo_name,
+            file_path=file_path,
         )
 
         if func_start is not None and func_end is not None:
@@ -170,8 +175,32 @@ class ContextExtractor:
         lines: list[str],
         target_line: int,
         lang: str,
+        repo_name: str = "",
+        file_path: str = "",
     ) -> tuple[int | None, int | None, str | None]:
         """Find the enclosing function boundaries for a target line."""
+        # 1. CSV lookup — primary: uses AST-derived data, no false positives from control flow
+        if self.output_dir and repo_name and file_path:
+            csv_path = self.output_dir / lang / repo_name / "context" / "functions.csv"
+            if csv_path.is_file():
+                try:
+                    import csv
+
+                    with open(csv_path, newline="", encoding="utf-8") as f:
+                        for row in csv.DictReader(f):
+                            if row.get("file", "") != file_path:
+                                continue
+                            try:
+                                start = int(row["start_line"])
+                                end = int(row["end_line"])
+                            except (KeyError, ValueError):
+                                continue
+                            if start <= target_line + 1 <= end:  # target_line is 0-indexed
+                                return start - 1, end - 1, row.get("name")
+                except OSError:
+                    pass  # fallback to regex
+
+        # 2. Regex fallback
         patterns = self._FUNCTION_PATTERNS.get(lang, self._FUNCTION_PATTERNS.get("c", []))
 
         # Search backward for function start

--- a/src/vuln_hunter_x/verification/engine.py
+++ b/src/vuln_hunter_x/verification/engine.py
@@ -60,6 +60,7 @@ def _downgrade_unsupported_confidence(verdict: Verdict) -> Verdict:
         )
     return verdict
 
+
 from vuln_hunter_x.context.extractor import ContextExtractor
 from vuln_hunter_x.context.provider import ContextProvider
 from vuln_hunter_x.core.config import Config, load_config
@@ -120,7 +121,9 @@ class VerificationEngine:
 
         # Initialize components
         self.questions_loader = questions_loader or QuestionsLoader(config.paths.prompts_dir)
-        self.context_extractor = context_extractor or ContextExtractor(config.paths.repos_dir)
+        self.context_extractor = context_extractor or ContextExtractor(
+            config.paths.repos_dir, config.paths.output_dir
+        )
 
         self.context_provider: ContextProvider | None = context_provider or ContextProvider(
             config.paths.output_dir,
@@ -138,6 +141,7 @@ class VerificationEngine:
         self._profile_manager = None
         try:
             from vuln_hunter_x.core.rule_profiles import RuleProfileManager
+
             categories_path = config.paths.base_dir / "config" / "rule_categories.yaml"
             if categories_path.is_file():
                 self._profile_manager = RuleProfileManager(categories_path)
@@ -150,6 +154,17 @@ class VerificationEngine:
         # Callbacks for progress reporting
         self._on_finding_start: Callable[[int, int, Finding], None] | None = None
         self._on_finding_complete: Callable[[int, int, Verdict], None] | None = None
+
+        # Open log file if configured
+        self._log_fh = (
+            open(config.output.log_file, "w", encoding="utf-8")  # noqa: SIM115
+            if config.output.log_file
+            else None
+        )
+
+    def __del__(self) -> None:
+        if self._log_fh:
+            self._log_fh.close()
 
     @classmethod
     def from_config(
@@ -275,10 +290,7 @@ class VerificationEngine:
         # Apply category filter (findings without CWE tags are always included)
         if category_filter and self._profile_manager:
             target_cwes = self._profile_manager.get_cwes_for_categories(category_filter)
-            findings = [
-                f for f in findings
-                if not f.cwe_ids or target_cwes.intersection(f.cwe_ids)
-            ]
+            findings = [f for f in findings if not f.cwe_ids or target_cwes.intersection(f.cwe_ids)]
 
         if limit > 0:
             findings = findings[:limit]
@@ -361,6 +373,7 @@ class VerificationEngine:
             finding.file,
             finding.start_line,
             finding.lang,
+            repo_name=finding.repo_name,
         )
 
         # Pre-fetch additional context declared by guided questions
@@ -379,9 +392,7 @@ class VerificationEngine:
 
         # Call LLM. When ``self_consistency_samples > 1`` we route through
         # the voting wrapper; otherwise we keep the single-pass fast path.
-        sc_samples = getattr(
-            self.config.verification, "self_consistency_samples", 1
-        )
+        sc_samples = getattr(self.config.verification, "self_consistency_samples", 1)
         if sc_samples > 1:
             verdict = self.llm_client.analyze_with_voting(
                 finding=finding,
@@ -405,6 +416,7 @@ class VerificationEngine:
                 quiet=self.config.output.is_quiet,
                 force_decision=self.config.verification.force_decision,
                 prefetched_context=prefetched_context,
+                log_file=self._log_fh,
             )
         else:
             verdict = self.llm_client.analyze(
@@ -418,6 +430,7 @@ class VerificationEngine:
                 quiet=self.config.output.is_quiet,
                 force_decision=self.config.verification.force_decision,
                 prefetched_context=prefetched_context,
+                log_file=self._log_fh,
             )
 
         # Confidence-discipline post-processor: a TP verdict whose reasoning is


### PR DESCRIPTION
## What
- Add CSV lookup as primary method in `_find_function_bounds` before falling back to regex
- Pass `output_dir` to `ContextExtractor.__init__` and `repo_name` to `get_context`

## Why
The existing C/C++ regex patterns in `_FUNCTION_PATTERNS` match leading whitespace (indent), causing control-flow statements like `if` and `while` to be incorrectly identified as function definitions. This results in the LLM receiving wrong function names and truncated code context.

Using `functions.csv` (extracted via CodeQL/tree-sitter during `prepare`) as the primary lookup avoids this issue since it is AST-derived and contains only real function definitions. Regex is kept as fallback when CSV is unavailable.