### PR TITLE
fix: correct end_line extraction in Python functions.ql

### DIFF
--- a/config/queries/tools/python/functions.ql
+++ b/config/queries/tools/python/functions.ql
@@ -15,5 +15,5 @@ select
   f.getName() as name,
   f.getLocation().getFile().getRelativePath() as file,
   f.getLocation().getStartLine() as start_line,
-  f.getLocation().getEndLine() as end_line,
+   f.getLastStatement().getLocation().getEndLine() as end_line,
   f.getScope().toString() as scope

--- a/config/queries/tools/python/functions.ql
+++ b/config/queries/tools/python/functions.ql
@@ -10,10 +10,16 @@
 
 import python
 
+int getFunctionEndLine(Function f) {
+  if exists(f.getLastStatement())
+  then result = f.getLastStatement().getLocation().getEndLine()
+  else result = f.getLocation().getEndLine()
+}
+
 from Function f
 select
   f.getName() as name,
   f.getLocation().getFile().getRelativePath() as file,
   f.getLocation().getStartLine() as start_line,
-   f.getLastStatement().getLocation().getEndLine() as end_line,
+  getFunctionEndLine(f) as end_line,
   f.getScope().toString() as scope


### PR DESCRIPTION
## What
Replaced `f.getLocation().getEndLine()` with `getFunctionEndLine()` helper in `functions.ql` to return the full function body end line instead of just the signature end line.

## Why
`getEndLine()` on the function node only covers the signature, causing incorrect `end_line` values in `functions.csv` for multi-line function signatures.