### PR TITLE
feat: Ollama Cloud support + benchmark report fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The **Vulnhalla** methodology forces the LLM to:
 | **SAST engines** | CodeQL, Semgrep, OpenGrep (`--tool codeql\|semgrep\|opengrep\|both\|all`) |
 | **Security rule profiles** | `standard` → `extended` → `maximum` → `extended-registry` → `full` (see [config/RULES.md](config/RULES.md)) |
 | **Guided questions** | 316 rule-specific templates across 6 per-language banks plus a fallback |
-| **LLM providers** | OpenAI, Anthropic, Ollama (via [LiteLLM](https://github.com/BerriAI/litellm)) |
+| **LLM providers** | OpenAI, Anthropic, Ollama (local or [Ollama Cloud](https://ollama.com)) — via [LiteLLM](https://github.com/BerriAI/litellm) |
 | **Multi-turn verification** | Dynamic context expansion (callers, structs, globals, macros, free-sites) |
 | **Inputs** | Git URL, local directory, or batch list (`repos.yaml`) |
 | **Reports** | Markdown, EN/VI, executive summary + per-finding detail |
@@ -358,7 +358,8 @@ Priority: **CLI args > environment variables > config file > defaults**.
 |---|---|
 | `OPENAI_API_KEY` | OpenAI API key |
 | `ANTHROPIC_API_KEY` | Anthropic API key |
-| `OLLAMA_API_BASE` | Ollama server URL |
+| `OLLAMA_API_BASE` | Ollama server URL (`http://localhost:11434` for local, `https://ollama.com` for cloud) |
+| `OLLAMA_API_KEY` | API key for Ollama Cloud (only required when `OLLAMA_API_BASE` points at `ollama.com`) |
 | `LLM_PROVIDER` / `LLM_MODEL` | Override default provider / model |
 | `CODEQL_PATH` / `SEMGREP_PATH` / `OPENGREP_PATH` | Tool paths if not on `PATH` |
 

--- a/benchmarks/adapters/cwe_rule_map.py
+++ b/benchmarks/adapters/cwe_rule_map.py
@@ -136,6 +136,36 @@ def primary_rule(cwe_id: str) -> str:
     return rules[0] if rules else ""
 
 
+# Map adapter-level language labels to the rule-prefix used in CWE_TO_RULES.
+# Adapters use "c" / "cpp" / "python" / "javascript" / "php" / "java"; the
+# rule IDs are prefixed with "cpp/" / "py/" / "js/" / "php/" / "java/".
+_LANG_TO_RULE_PREFIX: dict[str, str] = {
+    "c": "cpp/",
+    "cpp": "cpp/",
+    "python": "py/",
+    "javascript": "js/",
+    "typescript": "js/",
+    "php": "php/",
+    "java": "java/",
+}
+
+
+def primary_rule_for_lang(cwe_id: str, lang: str) -> str:
+    """Return the rule for ``cwe_id`` whose prefix matches ``lang``.
+
+    Falls back to :func:`primary_rule` when no rule matches the language.
+    Used by dataset adapters so that, e.g., a C file under ``CWE-22/`` gets
+    ``cpp/path-injection`` instead of ``py/path-injection`` (the latter
+    being the alphabetically-first entry in the CWE-22 list).
+    """
+    prefix = _LANG_TO_RULE_PREFIX.get(lang)
+    if prefix:
+        for rid in cwe_to_rules(cwe_id):
+            if rid.startswith(prefix):
+                return rid
+    return primary_rule(cwe_id)
+
+
 def all_mapped_cwes() -> list[str]:
     """Return all CWE IDs that have at least one rule mapping."""
     return sorted(CWE_TO_RULES.keys())

--- a/benchmarks/adapters/juliet_adapter.py
+++ b/benchmarks/adapters/juliet_adapter.py
@@ -25,7 +25,7 @@ import logging
 import re
 from pathlib import Path
 
-from benchmarks.adapters.cwe_rule_map import CWE_TO_RULES, primary_rule
+from benchmarks.adapters.cwe_rule_map import CWE_TO_RULES, primary_rule, primary_rule_for_lang
 from benchmarks.adapters.ground_truth import LABEL_FP, LABEL_TP, GroundTruthEntry
 
 logger = logging.getLogger(__name__)
@@ -170,11 +170,11 @@ class JulietAdapter:
             if cwe_no_dash not in active_cwes:
                 continue
 
-            rule_id = primary_rule(cwe_id)
             cwe_entries: list[GroundTruthEntry] = []
 
             for c_file in sorted(cwe_dir.rglob("*.c")) + sorted(cwe_dir.rglob("*.cpp")):
                 lang = "cpp" if c_file.suffix == ".cpp" else "c"
+                rule_id = primary_rule_for_lang(cwe_id, lang)
                 try:
                     code = c_file.read_text(encoding="utf-8", errors="replace")
                 except OSError:

--- a/benchmarks/adapters/realvuln_adapter.py
+++ b/benchmarks/adapters/realvuln_adapter.py
@@ -50,7 +50,7 @@ import logging
 from collections.abc import Callable
 from pathlib import Path
 
-from benchmarks.adapters.cwe_rule_map import primary_rule
+from benchmarks.adapters.cwe_rule_map import primary_rule_for_lang
 from benchmarks.adapters.ground_truth import LABEL_FP, LABEL_TP, GroundTruthEntry
 
 logger = logging.getLogger(__name__)
@@ -172,7 +172,7 @@ class RealVulnAdapter:
                         id=f"realvuln-{repo_id}-{finding_id}",
                         source_dataset="realvuln",
                         cwe_id=cwe_id,
-                        rule_id=primary_rule(cwe_id),
+                        rule_id=primary_rule_for_lang(cwe_id, lang),
                         file_path=file_rel,
                         function_name=func_name,
                         start_line=start_line or 1,

--- a/benchmarks/adapters/secllmholmes_adapter.py
+++ b/benchmarks/adapters/secllmholmes_adapter.py
@@ -31,7 +31,7 @@ import hashlib
 import logging
 from pathlib import Path
 
-from benchmarks.adapters.cwe_rule_map import primary_rule
+from benchmarks.adapters.cwe_rule_map import primary_rule_for_lang
 from benchmarks.adapters.ground_truth import LABEL_FP, LABEL_TP, GroundTruthEntry
 
 logger = logging.getLogger(__name__)
@@ -116,7 +116,6 @@ class SecLLMHolmesAdapter:
                 if not cwe_dir.is_dir() or not cwe_dir.name.startswith("CWE-"):
                     continue
                 cwe_id = cwe_dir.name  # e.g., "CWE-416"
-                rule_id = primary_rule(cwe_id)
 
                 for code_file in sorted(cwe_dir.iterdir()):
                     if not code_file.is_file():
@@ -125,6 +124,9 @@ class SecLLMHolmesAdapter:
                         continue
 
                     lang = _LANG_MAP[code_file.suffix.lower()]
+                    # Pick the rule whose prefix matches this file's language
+                    # so per-rule and per-language metrics line up.
+                    rule_id = primary_rule_for_lang(cwe_id, lang)
                     # p_ prefix = patched (safe), otherwise vulnerable
                     label = LABEL_FP if code_file.name.startswith("p_") else LABEL_TP
 

--- a/benchmarks/scripts/generate_report.py
+++ b/benchmarks/scripts/generate_report.py
@@ -111,6 +111,20 @@ def _run_metadata(run_dir: Path, summaries: list[dict]) -> str:
         wall_str = f"{mins}m {secs}s" if mins else f"{secs}s"
 
     total_cost = sum(s.get("total_cost_usd", 0.0) for s in summaries)
+    # Imputed cost (tokens × API list price) — populated even when LiteLLM has
+    # no price for the provider (e.g. Ollama Cloud, local Ollama, self-hosted
+    # OpenAI-compatible endpoints). Surface it alongside the real cost so
+    # cloud/free-tier runs aren't misread as zero-cost.
+    imputed_costs = [
+        s.get("imputed_api_cost_usd")
+        for s in summaries
+        if s.get("imputed_api_cost_usd") is not None
+    ]
+    total_imputed = sum(imputed_costs) if imputed_costs else None
+    if total_imputed is not None and (total_cost == 0.0 or total_imputed > total_cost):
+        cost_str = f"${total_cost:.4f} (imputed: ${total_imputed:.4f})"
+    else:
+        cost_str = f"${total_cost:.4f}"
 
     lines = [
         "## Run Info",
@@ -121,7 +135,7 @@ def _run_metadata(run_dir: Path, summaries: list[dict]) -> str:
         f"| **Datasets** | {', '.join(datasets)} |",
         f"| **Approaches** | {', '.join(approaches)} |",
         f"| **Wall time** | {wall_str} |",
-        f"| **Total cost** | ${total_cost:.4f} |",
+        f"| **Total cost** | {cost_str} |",
         f"| **Run dir** | `{run_dir}` |",
     ]
     return "\n".join(lines)
@@ -555,17 +569,26 @@ def _question_match_table(summaries: list[dict]) -> str:
 
 def _cost_table(summaries: list[dict]) -> str:
     """Build cost and latency table."""
-    headers = ["Approach", "Dataset", "Total Tokens", "Total Cost", "Mean Latency", "p95 Latency", "Iterations (mean/max)"]
+    headers = [
+        "Approach", "Dataset", "Total Tokens", "Total Cost",
+        "Mean Latency", "p95 Latency", "Iterations (mean/max)",
+    ]
     rows = [headers, ["---"] * len(headers)]
     for s in summaries:
         iters = (
             f"{_num(s.get('mean_iterations'), 1)} / {s.get('max_iterations', '—')}"
         )
+        real_cost = s.get("total_cost_usd", 0.0) or 0.0
+        imputed = s.get("imputed_api_cost_usd")
+        if imputed is not None and (real_cost == 0.0 or imputed > real_cost):
+            cost_cell = f"${real_cost:.4f} (imputed ${imputed:.4f})"
+        else:
+            cost_cell = f"${real_cost:.4f}"
         rows.append([
             s.get("approach", "?"),
             s.get("dataset", "?"),
             str(s.get("total_tokens", 0)),
-            f"${s.get('total_cost_usd', 0):.4f}",
+            cost_cell,
             _num(s.get("mean_latency_s")),
             _num(s.get("p95_latency_s")),
             iters,

--- a/config/prompts/cpp_questions.yaml
+++ b/config/prompts/cpp_questions.yaml
@@ -66,7 +66,7 @@ cpp/use-after-free:
   short_description: "Use of pointer after memory has been freed"
   questions:
     - "ANCHOR FIRST: quote the EXACT statement at the flagged line. Name the function it lives in. Classify the flagged line as one of: (a) a pointer USE (deref / read / write / pass-to-function), (b) a free/delete/destructor call, (c) a function signature or declaration, (d) something else. If (c) or (d), the SAST flag is suspect — record this and weight your verdict accordingly."
-    - "If the snippet contains MULTIPLE functions (e.g. helperBad + goodG2B, or production + test), identify which function the flagged line belongs to. Reason ONLY about that function's behavior. Do NOT convict based on UAF patterns visible in sibling functions."
+    - "If the snippet contains MULTIPLE functions (e.g. a vulnerable variant alongside a patched or test variant, or a helper alongside its caller), identify which function the flagged line belongs to. Reason ONLY about that function's behavior. Do NOT convict based on UAF patterns visible in sibling functions, regardless of how those functions are named."
     - "Where is the pointer at the flagged line ALLOCATED (malloc, calloc, new, strdup, custom allocator)? If allocation is in a DIFFERENT function, name that function — request 'caller:<func>' or 'all_callers:<func>' context if you cannot see it."
     - "List ALL free()/delete calls reachable from the flagged use — include the function name, file, and line number for EACH. If you cannot enumerate them from the snippet, request 'free_sites:<pointer_name>' context. Mark which frees are conditional (inside if/switch/error paths)."
     - "Is the pointer set to NULL immediately after EACH free? If not, what value does it hold?"
@@ -74,17 +74,17 @@ cpp/use-after-free:
     - "Does the pointer escape this function — is it stored in a struct field, global, returned, or passed to another function that retains it? If so, who is responsible for its lifetime?"
     - "Are there ALIAS pointers (copies, struct members, array entries, void* casts) that reference the same memory? Could one alias free while another still holds a reference?"
     - "If the pointer is REASSIGNED between free and use, where and to what value — a new allocation, NULL, or another pointer?"
-    - "DECISION RULE: only mark TP if you can produce a SPECIFIC triple — (free_site file:line, use_site file:line, control-flow path reaching the use after the free, in the SAME function or via caller). If your evidence is just 'this looks like a UAF pattern' without specific line numbers from the flagged function, mark NEEDS_MORE_DATA, NOT TP. If reasoning relies on a function named like 'helperBad' while the flagged line is in 'goodG2B', that is grounds for FP."
-  context_hint: "TRACE: allocation -> free -> flagged_use | NEED: caller(ptr_origin), struct(ptr_type_members), callees(functions_ptr_passed_to), free_sites(ptr_name), destructor(owner_type), field_writes(owner.ptr_field)"
-  additional_context: ["caller", "struct", "callees", "all_callers", "free_sites", "destructor", "field_writes"]
-  min_iterations: 2
+    - "DECISION RULE: mark TP when EITHER (a) you can produce a SPECIFIC triple — (free_site file:line, use_site file:line, control-flow path reaching the use after the free), OR (b) you can name the FREE FUNCTION and identify the flagged USE in the same function or a clear caller, AND there is no NULL-assignment, reassignment, or fresh reallocation between them. Mark FP ONLY when you have POSITIVE evidence of a defense: NULL-after-free, pointer reassigned to a fresh allocation, free on an unreachable branch, or the flagged line is a signature/declaration. Pattern-only reasoning based on function NAMES (e.g. assuming a function is buggy because of a suggestive identifier) without supporting code evidence is NOT enough to mark FP — prefer NEEDS_MORE_DATA in that case. The default for an undefended free→use chain in the flagged function is TP, not FP."
+  context_hint: "TRACE: allocation -> free -> flagged_use | NEED: free_sites(ptr_name) FIRST, then caller(ptr_origin), struct(ptr_type_members), callees(functions_ptr_passed_to), destructor(owner_type), field_writes(owner.ptr_field)"
+  additional_context: ["free_sites", "caller", "all_callers", "struct", "callees", "destructor", "field_writes"]
+  min_iterations: 3
   snippet_window_lines: 60
 
 cpp/double-free:
   short_description: "Memory freed more than once"
   questions:
     - "ANCHOR FIRST: quote the flagged line and name the function. Classify it as (a) a free/delete call, (b) a use leading to free elsewhere, (c) a signature/declaration. If (c), the flag is suspect."
-    - "If the snippet contains MULTIPLE functions (bad/good Juliet variants, helper + caller), restrict your reasoning to the function containing the flagged line. Do NOT convict on free-pairs visible in sibling functions."
+    - "If the snippet contains MULTIPLE functions (e.g. vulnerable and patched variants side-by-side, or a helper and its caller), restrict your reasoning to the function containing the flagged line. Do NOT convict on free-pairs visible in sibling functions, regardless of how those functions are named."
     - "Where is the pointer ALLOCATED and what variable holds it?"
     - "List ALL free() calls reachable from the flagged location with file:line — request 'free_sites:<pointer_name>' context if needed."
     - "For each pair of free() calls, is there a SPECIFIC code path that reaches BOTH? Describe the path or mark NEEDS_MORE_DATA."

--- a/config/prompts/system_prompt.yaml
+++ b/config/prompts/system_prompt.yaml
@@ -94,7 +94,7 @@ system_prompt: |
     "answers": ["answer to Q1 with line references", "answer to Q2", ...],
     "data_flow": "source (line N) → transform (line M) → sink (line K)",
     "verdict": "True Positive" | "False Positive" | "Needs More Data",
-    "confidence": "High" | "Medium" | "Low",
+    "confidence": "High" | "Medium" | "Low",  // EXACTLY one of these three — no "Very High", "VeryHigh", or other variants
     "confidence_score": 0.85,
     "reasoning": "1-2 sentence explanation referencing your answers and data flow",
     "context_needed": ["caller:main", "struct:buffer_t"]

--- a/env.example
+++ b/env.example
@@ -10,9 +10,10 @@
 LLM_PROVIDER=openai
 
 # Model name (must match the provider):
-#   OpenAI:    gpt-4o, gpt-4o-mini, gpt-4-turbo
-#   Anthropic: claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5-20251001
-#   Ollama:    ollama/llama3.2, ollama/qwen3:latest, ollama/codellama
+#   OpenAI:       gpt-4o, gpt-4o-mini, gpt-4-turbo
+#   Anthropic:    claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5-20251001
+#   Ollama local: ollama/llama3.2, ollama/qwen3:latest, ollama/codellama
+#   Ollama Cloud: gpt-oss:120b-cloud, qwen3-coder:480b-cloud, deepseek-v3.1:671b-cloud
 LLM_MODEL=gpt-4o
 
 # =============================================================================
@@ -31,10 +32,15 @@ OPENAI_API_KEY=your_openai_api_key_here
 # ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
 # =============================================================================
-# Ollama (local or remote open-source models)
+# Ollama (local or Ollama Cloud)
 # =============================================================================
 
+# Local Ollama:
 # OLLAMA_API_BASE=http://localhost:11434
+
+# Ollama Cloud (https://ollama.com):
+# OLLAMA_API_BASE=https://ollama.com
+# OLLAMA_API_KEY=your_ollama_cloud_api_key_here
 
 # =============================================================================
 # Tool Paths (if not on PATH)

--- a/src/vuln_hunter_x/cli/env.py
+++ b/src/vuln_hunter_x/cli/env.py
@@ -302,6 +302,21 @@ def check_ollama(
     )
     api_base = api_base.strip() or None
 
+    # Ollama Cloud requires a bearer token and uses the chat-completions route.
+    # Detect cloud by endpoint OR model tag (:cloud / -cloud suffix).
+    bare_model = model.removeprefix("ollama_chat/").removeprefix("ollama/")
+    tag_is_cloud = bare_model.endswith(":cloud") or bare_model.endswith("-cloud")
+    is_cloud = bool((api_base and "ollama.com" in api_base) or tag_is_cloud)
+    if is_cloud:
+        cloud_key = os.environ.get("OLLAMA_API_KEY", "").strip()
+        if not cloud_key:
+            return False, (
+                "Ollama Cloud model detected but OLLAMA_API_KEY is not set"
+            )
+        model = "ollama_chat/" + bare_model
+        if not api_base or "ollama.com" not in api_base:
+            api_base = "https://ollama.com"
+
     try:
         kwargs: dict = {
             "model": model,
@@ -310,6 +325,8 @@ def check_ollama(
         }
         if api_base:
             kwargs["api_base"] = api_base.rstrip("/")
+        if is_cloud:
+            kwargs["api_key"] = os.environ["OLLAMA_API_KEY"].strip()
 
         resp = litellm.completion(**kwargs)
         text = (resp.choices[0].message.content or "").strip()

--- a/src/vuln_hunter_x/core/validation.py
+++ b/src/vuln_hunter_x/core/validation.py
@@ -51,10 +51,14 @@ def validate_file_path(path: Path, base: Path) -> Path:
 
 
 def normalize_ollama_model(model: str) -> str:
-    """Ensure Ollama model names have the 'ollama/' prefix."""
-    if not model.startswith("ollama/"):
-        return f"ollama/{model}"
-    return model
+    """Ensure Ollama model names have the 'ollama/' prefix.
+
+    Leaves 'ollama_chat/' prefixes alone — that's the chat-completions
+    route used for Ollama Cloud.
+    """
+    if model.startswith(("ollama/", "ollama_chat/")):
+        return model
+    return f"ollama/{model}"
 
 
 def openai_compat_kwargs(

--- a/src/vuln_hunter_x/llm/client.py
+++ b/src/vuln_hunter_x/llm/client.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 VinSOC Cyber
 
-"""LLM client abstraction for OpenAI and Ollama via LiteLLM."""
+"""LLM client abstraction for OpenAI, Anthropic, and Ollama (local + cloud) via LiteLLM."""
 
 from __future__ import annotations
 
@@ -92,8 +92,25 @@ class LLMClient:
         self.prompt_builder = PromptBuilder()
 
         # Configure provider-specific settings
+        self._is_ollama_cloud = False
         if provider == "ollama":
-            ollama_base = os.environ.get("OLLAMA_API_BASE", DEFAULT_OLLAMA_BASE_URL)
+            ollama_base = os.environ.get("OLLAMA_API_BASE", "").strip()
+            # Ollama Cloud (ollama.com) uses bearer-auth chat-completions; local
+            # ollama (localhost:11434) does not. Detect cloud by either the
+            # endpoint or the model tag (cloud models carry a ":cloud" or
+            # "-cloud" suffix, e.g. gpt-oss:120b-cloud, qwen3-coder-next:cloud).
+            bare_model = self.model.removeprefix("ollama_chat/").removeprefix("ollama/")
+            tag_is_cloud = bare_model.endswith(":cloud") or bare_model.endswith("-cloud")
+            self._is_ollama_cloud = "ollama.com" in ollama_base or tag_is_cloud
+            if self._is_ollama_cloud:
+                if "ollama.com" not in ollama_base:
+                    ollama_base = "https://ollama.com"
+                if not self.model.startswith("ollama_chat/"):
+                    self.model = "ollama_chat/" + bare_model
+            else:
+                ollama_base = ollama_base or DEFAULT_OLLAMA_BASE_URL
+                if not self.model.startswith(("ollama/", "ollama_chat/")):
+                    self.model = "ollama/" + self.model
             os.environ["OLLAMA_API_BASE"] = ollama_base
         elif provider == "anthropic":
             # LiteLLM reads ANTHROPIC_API_KEY from the environment automatically.
@@ -124,6 +141,11 @@ class LLMClient:
         }
         if api_base:
             kwargs["api_base"] = api_base
+        if self.provider == "ollama" and self._is_ollama_cloud:
+            kwargs["api_base"] = os.environ["OLLAMA_API_BASE"].rstrip("/")
+            cloud_key = os.environ.get("OLLAMA_API_KEY")
+            if cloud_key:
+                kwargs["api_key"] = cloud_key
         if self.num_retries:
             # LiteLLM retries RateLimitError / APIConnectionError / Timeout /
             # InternalServerError with exponential backoff and honors Retry-After.
@@ -807,23 +829,49 @@ class LLMClient:
         )
 
     _CONFIDENCE_SCORE_MAP = {"high": 0.85, "medium": 0.6, "low": 0.3}
+    # Variants outside the {High, Medium, Low} vocabulary that we silently
+    # remap. The LLM has historically emitted "Very High" / "VeryHigh" /
+    # "Highly Confident" despite the prompt schema; rather than rejecting
+    # them (which would lose signal), we collapse them to the nearest valid
+    # bucket so calibration and CISC voting remain meaningful.
+    _CONFIDENCE_ALIASES = {
+        "veryhigh": "High",
+        "very high": "High",
+        "highly confident": "High",
+        "extremely high": "High",
+        "certain": "High",
+        "high confidence": "High",
+        "medium-high": "High",
+        "mediumhigh": "High",
+        "moderate": "Medium",
+        "medium-low": "Low",
+        "mediumlow": "Low",
+        "very low": "Low",
+        "verylow": "Low",
+        "uncertain": "Low",
+    }
+    _VALID_CONFIDENCE = {"High", "Medium", "Low"}
+
+    @classmethod
+    def _normalize_confidence_label(cls, raw: Any) -> str:
+        """Map any incoming confidence label to {High, Medium, Low}."""
+        if not isinstance(raw, str):
+            return "Low"
+        key = raw.strip().casefold()
+        if key in cls._CONFIDENCE_SCORE_MAP:
+            return key.capitalize()
+        if key in cls._CONFIDENCE_ALIASES:
+            return cls._CONFIDENCE_ALIASES[key]
+        return "Low"
 
     @classmethod
     def _ensure_confidence_score(cls, parsed: dict[str, Any]) -> dict[str, Any]:
-        """Ensure parsed response has a numeric confidence_score field."""
-        if "confidence_score" not in parsed or not isinstance(
-            parsed.get("confidence_score"), (int, float)
-        ):
-            confidence_value = parsed.get("confidence", "Low")
-            if isinstance(confidence_value, str):
-                normalized_confidence = confidence_value.strip().casefold()
-            else:
-                normalized_confidence = ""
-            score = cls._CONFIDENCE_SCORE_MAP.get(normalized_confidence)
-            if score is None:
-                # Default to low confidence when the label is unrecognized
-                score = 0.3
-            parsed["confidence_score"] = score
+        """Normalize confidence label and ensure a numeric confidence_score."""
+        parsed["confidence"] = cls._normalize_confidence_label(parsed.get("confidence"))
+        if not isinstance(parsed.get("confidence_score"), (int, float)):
+            parsed["confidence_score"] = cls._CONFIDENCE_SCORE_MAP[
+                parsed["confidence"].casefold()
+            ]
         return parsed
 
     def _parse_response(self, raw: str) -> dict[str, Any]:

--- a/src/vuln_hunter_x/llm/prompts.py
+++ b/src/vuln_hunter_x/llm/prompts.py
@@ -130,7 +130,7 @@ Response format (strict JSON):
   "answers": ["answer to Q1 with line references", "answer to Q2", ...],
   "data_flow": "source (line N) → transform (line M) → sink (line K)",
   "verdict": "True Positive" | "False Positive" | "Needs More Data",
-  "confidence": "High" | "Medium" | "Low",
+  "confidence": "High" | "Medium" | "Low",  // EXACTLY one of these three — no "Very High", "VeryHigh", or other variants
   "confidence_score": 0.85,
   "reasoning": "1-2 sentence explanation referencing your answers and data flow",
   "context_needed": ["caller:main", "struct:buffer_t"]


### PR DESCRIPTION
Ollama Cloud:
- Route ollama.com endpoints through LiteLLM's ollama_chat/ provider with bearer auth (OLLAMA_API_KEY); auto-detect cloud from the endpoint or the model's :cloud / -cloud tag. Local Ollama unchanged.
- check-env warns when a cloud model is configured without an API key.
- README + env.example document the new variable and cloud model names.

Confidence calibration:
- Normalize confidence labels to {High, Medium, Low}; map common variants ("Very High", "VeryHigh", "Moderate", ...) into the valid vocabulary so CISC voting weights and calibration buckets stop fragmenting across spelling variants.
- Tighten the JSON schema clause in the system prompt to forbid out-of-vocabulary labels.

CWE-416 UAF prompt:
- Soften DECISION RULE: an undefended free→use chain in the flagged function defaults to TP, not FP. Mark FP only when there is positive evidence of a defense.
- Bump min_iterations 2 → 3 and reorder additional_context so the model hits free_sites first.
- Generalize wording: replace Juliet-specific names (helperBad, goodG2B) with "vulnerable variant alongside a patched or test variant" so prompts don't prime the model on benchmark vocabulary.

Benchmark plumbing:
- New primary_rule_for_lang(cwe_id, lang) — picks the rule whose prefix matches the source language. SecLLMHolmes, Juliet, and RealVuln adapters use it so per-rule / per-language tables no longer mislabel py/path-injection as lang=c, etc.
- generate_report surfaces imputed_api_cost_usd alongside Total cost when LiteLLM has no price for the provider (Ollama Cloud, local Ollama, self-hosted OpenAI-compatible endpoints) so zero-cost rows aren't misread as free.