### PR TITLE
Refactor dataset and approach handling with registry pattern

### DIFF
--- a/benchmarks/adapters/cwe_rule_map.py
+++ b/benchmarks/adapters/cwe_rule_map.py
@@ -166,6 +166,27 @@ def primary_rule_for_lang(cwe_id: str, lang: str) -> str:
     return primary_rule(cwe_id)
 
 
+def primary_rule_for_langs(cwe_id: str, langs: tuple[str, ...]) -> str:
+    """Return the first CodeQL rule for ``cwe_id`` matching ANY of ``langs``.
+
+    This generalises :func:`primary_rule_for_lang` to dataset adapters
+    that span multiple languages (e.g. ``DiverseVulAdapter`` covers both
+    ``c`` and ``cpp`` — both prefer the ``cpp/`` rule family).
+    Falls back to :func:`primary_rule` if no rule matches.
+    """
+    seen: set[str] = set()
+    prefixes: list[str] = []
+    for lang in langs:
+        prefix = _LANG_TO_RULE_PREFIX.get(lang)
+        if prefix and prefix not in seen:
+            seen.add(prefix)
+            prefixes.append(prefix)
+    for rid in cwe_to_rules(cwe_id):
+        if any(rid.startswith(p) for p in prefixes):
+            return rid
+    return primary_rule(cwe_id)
+
+
 def all_mapped_cwes() -> list[str]:
     """Return all CWE IDs that have at least one rule mapping."""
     return sorted(CWE_TO_RULES.keys())

--- a/benchmarks/adapters/diversevul_adapter.py
+++ b/benchmarks/adapters/diversevul_adapter.py
@@ -22,8 +22,15 @@ import json
 import logging
 from pathlib import Path
 
-from benchmarks.adapters.cwe_rule_map import cwe_to_rules, primary_rule
+from benchmarks.adapters.cwe_rule_map import primary_rule_for_langs
 from benchmarks.adapters.ground_truth import LABEL_FP, LABEL_TP, GroundTruthEntry
+from benchmarks.adapters.registry import (
+    DatasetAdapter,
+    OptionSpec,
+    _to_bool,
+    _to_csv_list,
+    register_adapter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +38,32 @@ logger = logging.getLogger(__name__)
 _MAX_SNIPPET_CHARS = 8000
 
 
-class DiverseVulAdapter:
+@register_adapter
+class DiverseVulAdapter(DatasetAdapter):
     """Adapter for the DiverseVul dataset."""
+
+    name = "diversevul"
+    langs = ("c", "cpp")
+    family = "cve"
+    option_schema = {
+        "cwes": OptionSpec(
+            _to_csv_list,
+            default=None,
+            help="Comma-separated CWE IDs to filter (e.g. CWE-787,CWE-416).",
+        ),
+        "include_unknown_cwe": OptionSpec(
+            _to_bool,
+            default=False,
+            help="Keep records whose CVE has no CWE mapping (dropped by default).",
+        ),
+        "negative_fraction": OptionSpec(
+            float,
+            default=None,
+            help="Rebalance to this fraction of target=0 records (e.g. 0.5).",
+        ),
+    }
+    install_url = "https://drive.google.com/uc?id=1-1Lhr-Fp1jB7CRf3lEpoFvz3UPDDfQOj"
+    expected_files = ("diversevul_20230702.json",)
 
     def __init__(self, dataset_path: Path) -> None:
         self.dataset_path = Path(dataset_path)
@@ -291,16 +322,12 @@ class DiverseVulAdapter:
 
         # Synthesise a rule_id from the CWE so the questions loader can
         # exact-match instead of falling to the default-question bucket.
-        # DiverseVul is C/C++, so prefer cpp/ rules; fall back to the primary
-        # rule when no cpp/ variant is registered.
+        # The language-preference logic lives in cwe_rule_map.primary_rule_for_langs,
+        # so adding a new dataset with different language coverage is a
+        # one-line change (just pass the adapter's `langs` tuple).
         rule_id = ""
         if cwe_id != "Unknown":
-            for rule in cwe_to_rules(cwe_id):
-                if rule.startswith("cpp/") or rule.startswith("c/"):
-                    rule_id = rule
-                    break
-            if not rule_id:
-                rule_id = primary_rule(cwe_id) or ""
+            rule_id = primary_rule_for_langs(cwe_id, self.langs) or ""
 
         # Deduplicate by function hash
         func_hash = hashlib.md5(func.encode(), usedforsecurity=False).hexdigest()[:12]

--- a/benchmarks/adapters/juliet_adapter.py
+++ b/benchmarks/adapters/juliet_adapter.py
@@ -27,6 +27,12 @@ from pathlib import Path
 
 from benchmarks.adapters.cwe_rule_map import CWE_TO_RULES, primary_rule, primary_rule_for_lang
 from benchmarks.adapters.ground_truth import LABEL_FP, LABEL_TP, GroundTruthEntry
+from benchmarks.adapters.registry import (
+    DatasetAdapter,
+    OptionSpec,
+    _to_bool,
+    register_adapter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,12 +89,36 @@ def _contains_good_function(code: str) -> bool:
     return bool(re.search(r"\bvoid\s+good\d*\s*\(", code))
 
 
-class JulietAdapter:
+@register_adapter
+class JulietAdapter(DatasetAdapter):
     """Parse Juliet C/C++ test cases into GroundTruthEntry objects.
 
     Mode "offline": synthesize entries from filename/function conventions.
                     Does not require CodeQL to be installed.
     """
+
+    name = "juliet"
+    langs = ("c", "cpp")
+    family = "synthetic"
+    option_schema = {
+        "mode": OptionSpec(
+            str,
+            default="offline",
+            help="Operational mode: 'offline' (filename convention) or 'full' (requires CodeQL).",
+        ),
+        "per_cwe_limit": OptionSpec(
+            int,
+            default=0,
+            help="Max entries per CWE, balanced TP/FP (N//2 each). 0 = no per-CWE cap.",
+        ),
+        "benchmark_cwes_only": OptionSpec(
+            _to_bool,
+            default=True,
+            help="Restrict to the standard benchmark CWE set.",
+        ),
+    }
+    install_url = "https://samate.nist.gov/SARD/downloads/test-suites/2017-10-01-juliet-test-suite-for-c-cplusplus-v1-3.zip"
+    expected_files = ("C/testcases",)
 
     def __init__(self, dataset_path: Path) -> None:
         self.dataset_path = Path(dataset_path)

--- a/benchmarks/adapters/owasp_benchmark_adapter.py
+++ b/benchmarks/adapters/owasp_benchmark_adapter.py
@@ -44,6 +44,7 @@ from pathlib import Path
 
 from benchmarks.adapters.cwe_rule_map import cwe_to_rules, primary_rule
 from benchmarks.adapters.ground_truth import LABEL_FP, LABEL_TP, GroundTruthEntry
+from benchmarks.adapters.registry import DatasetAdapter, register_adapter
 
 logger = logging.getLogger(__name__)
 
@@ -171,3 +172,40 @@ class OwaspBenchmarkAdapter:
             self.lang, len(entries), self.dataset_path, manifest.name,
         )
         return entries
+
+
+# ── Registry-facing thin subclasses ──────────────────────────────────
+# The base ``OwaspBenchmarkAdapter`` takes ``lang`` at __init__ time,
+# which doesn't fit the DatasetAdapter contract (``Adapter(dataset_path)``).
+# These subclasses pin ``lang`` at the class level so the registry can
+# instantiate them generically. Behaviour is otherwise identical.
+
+
+@register_adapter
+class OwaspJavaAdapter(OwaspBenchmarkAdapter, DatasetAdapter):
+    """OWASP BenchmarkJava — registry-facing wrapper."""
+
+    name = "owasp-java"
+    langs = ("java",)
+    family = "owasp"
+    option_schema: dict = {}
+    install_url = "https://github.com/OWASP-Benchmark/BenchmarkJava.git"
+    expected_files = ("expectedresults-",)
+
+    def __init__(self, dataset_path: Path) -> None:
+        super().__init__(dataset_path, lang="java")
+
+
+@register_adapter
+class OwaspPythonAdapter(OwaspBenchmarkAdapter, DatasetAdapter):
+    """OWASP BenchmarkPython — registry-facing wrapper."""
+
+    name = "owasp-python"
+    langs = ("python",)
+    family = "owasp"
+    option_schema: dict = {}
+    install_url = "https://github.com/OWASP-Benchmark/BenchmarkPython.git"
+    expected_files = ("expectedresults-",)
+
+    def __init__(self, dataset_path: Path) -> None:
+        super().__init__(dataset_path, lang="python")

--- a/benchmarks/adapters/realvuln_adapter.py
+++ b/benchmarks/adapters/realvuln_adapter.py
@@ -52,6 +52,7 @@ from pathlib import Path
 
 from benchmarks.adapters.cwe_rule_map import primary_rule_for_lang
 from benchmarks.adapters.ground_truth import LABEL_FP, LABEL_TP, GroundTruthEntry
+from benchmarks.adapters.registry import DatasetAdapter, register_adapter
 
 logger = logging.getLogger(__name__)
 
@@ -85,15 +86,25 @@ def _read_lines(path: Path, start: int, end: int, pad: int = 0) -> str:
     return "\n".join(lines[s:e])
 
 
-class RealVulnAdapter:
+@register_adapter
+class RealVulnAdapter(DatasetAdapter):
     """Parse RealVuln Benchmark ground-truth JSON files into GroundTruthEntry.
 
     Args:
         dataset_path: Root of the cloned Real-Vuln-Benchmark repository.
         repos_cache: Optional directory containing checked-out source trees
             keyed by repo_id. If absent, snippets are left empty.
+            Programmatic-only — not exposed via the registry CLI.
         code_resolver: Optional callable for tests to inject snippets.
+            Programmatic-only — not exposed via the registry CLI.
     """
+
+    name = "realvuln"
+    langs = ("python",)
+    family = "cve"
+    option_schema: dict = {}
+    install_url = "https://github.com/kolega-ai/Real-Vuln-Benchmark.git"
+    expected_files = ("ground-truth",)
 
     def __init__(
         self,

--- a/benchmarks/adapters/registry.py
+++ b/benchmarks/adapters/registry.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 VinSOC Cyber
+
+"""Dataset adapter registry — replaces the hard-coded if/else dispatch in
+``benchmarks/scripts/run_benchmark.py:_load_dataset`` and the parallel
+``DATASETS`` dict in ``setup_datasets.py``.
+
+Adding a new dataset is now a one-file change: implement the adapter,
+declare ``name`` / ``langs`` / ``option_schema``, decorate with
+``@register_adapter``. The CLI dispatcher resolves by name, validates
+options against ``option_schema`` (warning on unknowns instead of silent
+acceptance), and forwards.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar
+
+from benchmarks.adapters.ground_truth import GroundTruthEntry
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OptionSpec:
+    """A single dataset-adapter option declaration.
+
+    ``coerce`` is applied to CLI-string values before forwarding to the
+    adapter. Use ``str``, ``int``, ``float``, or ``_to_bool`` from this
+    module. For list-of-string options (e.g. ``cwes``) pass a callable
+    that splits ``"CWE-89,CWE-94"``-style values.
+    """
+
+    coerce: Any                  # callable: str -> typed value
+    default: Any = None
+    help: str = ""
+
+
+def _to_bool(s: str) -> bool:
+    if isinstance(s, bool):
+        return s
+    v = str(s).strip().lower()
+    if v in ("1", "true", "yes", "y", "on"):
+        return True
+    if v in ("0", "false", "no", "n", "off"):
+        return False
+    raise ValueError(f"cannot coerce {s!r} to bool")
+
+
+def _to_csv_list(s: str) -> list[str]:
+    if isinstance(s, list):
+        return [str(x) for x in s]
+    return [piece.strip() for piece in str(s).split(",") if piece.strip()]
+
+
+class DatasetAdapter(ABC):
+    """Base class every dataset adapter must inherit.
+
+    Concrete adapters declare class-level metadata so the registry can
+    dispatch CLI requests, validate options, and (eventually) drive
+    ``setup_datasets.py`` from the same source. Instances are constructed
+    by the dispatcher as ``Adapter(dataset_path)``.
+    """
+
+    # ── Class-level metadata (override in subclasses) ──
+    name: ClassVar[str] = ""
+    langs: ClassVar[tuple[str, ...]] = ()
+    family: ClassVar[str] = ""  # e.g. "owasp", "cve" — used by the "all"/family aliases
+    option_schema: ClassVar[dict[str, OptionSpec]] = {}
+    # ``install_url`` and ``expected_files`` are read by setup_datasets.py
+    # via the manifest, not from these class attributes — kept here as
+    # documentation hooks for adapter authors.
+    install_url: ClassVar[str | None] = None
+    expected_files: ClassVar[tuple[str, ...]] = ()
+
+    @abstractmethod
+    def __init__(self, dataset_path: Path) -> None: ...
+
+    @abstractmethod
+    def load(self, limit: int = 0, **options: Any) -> list[GroundTruthEntry]:
+        """Load entries from the dataset. Concrete signature accepts only
+        options declared in this class's ``option_schema``."""
+        ...
+
+
+_REGISTRY: dict[str, type[DatasetAdapter]] = {}
+
+
+def register_adapter(cls: type[DatasetAdapter]) -> type[DatasetAdapter]:
+    """Decorator: register a DatasetAdapter subclass by its ``name``."""
+    if not issubclass(cls, DatasetAdapter):
+        raise TypeError(f"{cls!r} must inherit DatasetAdapter")
+    if not cls.name:
+        raise ValueError(f"{cls.__name__} must declare a non-empty class attr 'name'")
+    if cls.name in _REGISTRY and _REGISTRY[cls.name] is not cls:
+        raise ValueError(
+            f"duplicate dataset adapter registration for name {cls.name!r}: "
+            f"{_REGISTRY[cls.name].__name__} vs {cls.__name__}"
+        )
+    _REGISTRY[cls.name] = cls
+    return cls
+
+
+def get_adapter(name: str) -> type[DatasetAdapter]:
+    """Resolve a name to an adapter class. Raises ``KeyError`` on miss."""
+    _ensure_loaded()
+    try:
+        return _REGISTRY[name]
+    except KeyError as exc:
+        raise KeyError(
+            f"unknown dataset {name!r}; registered: {sorted(_REGISTRY)}"
+        ) from exc
+
+
+def all_adapter_names() -> list[str]:
+    """All registered dataset names, sorted."""
+    _ensure_loaded()
+    return sorted(_REGISTRY)
+
+
+def adapters_in_family(family: str) -> list[str]:
+    """All registered dataset names whose ``family`` matches.
+
+    Used to expand aliases like ``--dataset owasp`` to all OWASP adapters
+    without hard-coding a list.
+    """
+    _ensure_loaded()
+    return sorted(
+        name for name, cls in _REGISTRY.items() if cls.family == family
+    )
+
+
+def coerce_options(
+    name: str, options: dict[str, Any]
+) -> tuple[dict[str, Any], list[str]]:
+    """Validate and coerce a free-form options dict against the adapter's
+    ``option_schema``.
+
+    Returns ``(valid_options, ignored_keys)``. Ignored keys are NOT raised
+    — they emit a logger warning at the call site. Coercion failures DO
+    raise ``ValueError`` so a user typo doesn't silently produce wrong
+    results.
+    """
+    cls = get_adapter(name)
+    valid: dict[str, Any] = {}
+    ignored: list[str] = []
+    for key, raw in options.items():
+        spec = cls.option_schema.get(key)
+        if spec is None:
+            ignored.append(key)
+            continue
+        try:
+            valid[key] = spec.coerce(raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"option {key}={raw!r} for dataset {name!r}: {exc}"
+            ) from exc
+    return valid, ignored
+
+
+def load_dataset(
+    name: str,
+    dataset_path: Path,
+    limit: int = 0,
+    options: dict[str, Any] | None = None,
+) -> list[GroundTruthEntry]:
+    """Single entry point: resolve adapter, coerce options, call .load().
+
+    Caller-supplied options that aren't in the adapter's ``option_schema``
+    are warned about and dropped — preserves the historic behaviour of
+    not crashing on unknown flags, but makes leakage visible.
+    """
+    cls = get_adapter(name)
+    valid, ignored = coerce_options(name, options or {})
+    if ignored:
+        logger.warning(
+            "ignored unknown dataset options for %s: %s "
+            "(valid keys: %s)",
+            name,
+            ignored,
+            sorted(cls.option_schema),
+        )
+    return cls(dataset_path).load(limit=limit, **valid)
+
+
+# ── Lazy import-time loading ─────────────────────────────────────────
+# Concrete adapter modules import this module to call @register_adapter.
+# To avoid circular imports, the adapter modules are imported lazily
+# the first time a registry query happens.
+
+_LOADED = False
+
+
+def _ensure_loaded() -> None:
+    global _LOADED
+    if _LOADED:
+        return
+    _LOADED = True  # set first so re-entry from imports doesn't recurse
+    # Import each adapter module for its side-effect (@register_adapter).
+    # Modules that fail to import are skipped with a warning — keeps the
+    # registry usable for the others.
+    for modname in (
+        "benchmarks.adapters.diversevul_adapter",
+        "benchmarks.adapters.juliet_adapter",
+        "benchmarks.adapters.secllmholmes_adapter",
+        "benchmarks.adapters.realvuln_adapter",
+        "benchmarks.adapters.owasp_benchmark_adapter",
+    ):
+        try:
+            __import__(modname)
+        except Exception:  # noqa: BLE001
+            logger.warning("failed to import adapter module %s", modname, exc_info=True)
+
+
+# Re-exports
+__all__ = [
+    "DatasetAdapter",
+    "OptionSpec",
+    "register_adapter",
+    "get_adapter",
+    "all_adapter_names",
+    "adapters_in_family",
+    "coerce_options",
+    "load_dataset",
+    "_to_bool",
+    "_to_csv_list",
+]

--- a/benchmarks/adapters/secllmholmes_adapter.py
+++ b/benchmarks/adapters/secllmholmes_adapter.py
@@ -33,6 +33,7 @@ from pathlib import Path
 
 from benchmarks.adapters.cwe_rule_map import primary_rule_for_lang
 from benchmarks.adapters.ground_truth import LABEL_FP, LABEL_TP, GroundTruthEntry
+from benchmarks.adapters.registry import DatasetAdapter, register_adapter
 
 logger = logging.getLogger(__name__)
 
@@ -55,12 +56,20 @@ _LANG_MAP: dict[str, str] = {
 }
 
 
-class SecLLMHolmesAdapter:
+@register_adapter
+class SecLLMHolmesAdapter(DatasetAdapter):
     """Parse SecLLMHolmes scenarios into GroundTruthEntry objects.
 
     Expects the repo to be cloned at `dataset_path` (the repo root or
     the `datasets/` directory inside it).
     """
+
+    name = "secllmholmes"
+    langs = ("c", "cpp", "python", "javascript", "php")
+    family = "academic"
+    option_schema: dict = {}
+    install_url = "https://github.com/Ahmed-Ucsd/SecLLMHolmes.git"
+    expected_files = ("datasets",)
 
     def __init__(self, dataset_path: Path) -> None:
         self.dataset_path = Path(dataset_path)

--- a/benchmarks/approaches/ablation.py
+++ b/benchmarks/approaches/ablation.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import Any
 
 from vuln_hunter_x.core.config import Config
 from vuln_hunter_x.core.types import GuidedQuestions
@@ -30,13 +31,18 @@ from vuln_hunter_x.questions.loader import QuestionsLoader
 from vuln_hunter_x.verification.engine import VerificationEngine
 
 from benchmarks.adapters.ground_truth import GroundTruthEntry
+from benchmarks.adapters.registry import OptionSpec
 from benchmarks.approaches.base import (
-    BenchmarkApproach,
     BenchmarkResult,
     _SnippetContextExtractor,
     _dry_run_result,
     entry_to_finding,
     verdict_to_pred,
+)
+from benchmarks.approaches.registry import (
+    LLMConfig,
+    RegisteredApproach,
+    register_approach,
 )
 
 # Default prompts directory (all language-specific YAMLs)
@@ -44,7 +50,8 @@ _PROMPTS_DIR = Path(__file__).resolve().parents[2] / "config" / "prompts"
 _DEFAULT_QUESTIONS_FILE = _PROMPTS_DIR / "default_questions.yaml"
 
 
-class AblationApproach(BenchmarkApproach):
+@register_approach
+class AblationApproach(RegisteredApproach):
     """Runs each finding through three question variants and returns all three results.
 
     Because BenchmarkApproach.evaluate() returns a single BenchmarkResult, this
@@ -58,6 +65,27 @@ class AblationApproach(BenchmarkApproach):
     """
 
     name = "ablation"
+    requires_llm = True
+    is_baseline = False
+    option_schema = {
+        "max_iterations": OptionSpec(
+            int,
+            default=3,
+            help="Max LLM turns per finding (applied to each ablation variant).",
+        ),
+    }
+
+    @classmethod
+    def from_options(
+        cls, llm: LLMConfig | None, options: dict[str, Any]
+    ) -> "AblationApproach":
+        llm = llm or LLMConfig()
+        return cls(
+            provider=llm.provider,
+            model=llm.model,
+            dry_run=llm.dry_run,
+            max_iterations=options.get("max_iterations", 3),
+        )
 
     def __init__(
         self,

--- a/benchmarks/approaches/raw_sast.py
+++ b/benchmarks/approaches/raw_sast.py
@@ -6,12 +6,19 @@
 from __future__ import annotations
 
 import time
+from typing import Any
 
 from benchmarks.adapters.ground_truth import GroundTruthEntry
-from benchmarks.approaches.base import PRED_TP, BenchmarkApproach, BenchmarkResult
+from benchmarks.approaches.base import PRED_TP, BenchmarkResult
+from benchmarks.approaches.registry import (
+    LLMConfig,
+    RegisteredApproach,
+    register_approach,
+)
 
 
-class RawSastApproach(BenchmarkApproach):
+@register_approach
+class RawSastApproach(RegisteredApproach):
     """Baseline 1: every finding is a TP.
 
     This measures CodeQL/Semgrep's native precision and establishes the upper bound
@@ -20,6 +27,16 @@ class RawSastApproach(BenchmarkApproach):
     """
 
     name = "raw-sast"
+    requires_llm = False
+    is_baseline = True
+    option_schema: dict = {}
+
+    @classmethod
+    def from_options(
+        cls, llm: LLMConfig | None, options: dict[str, Any]
+    ) -> "RawSastApproach":
+        # No options or LLM context to apply.
+        return cls()
 
     def evaluate(self, entry: GroundTruthEntry) -> BenchmarkResult:
         start = time.monotonic()

--- a/benchmarks/approaches/registry.py
+++ b/benchmarks/approaches/registry.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 VinSOC Cyber
+
+"""Benchmark-approach registry — mirrors ``benchmarks.adapters.registry``.
+
+Replaces the hard-coded if/else in
+``benchmarks/scripts/run_benchmark.py:_build_approach`` with a registry
+dispatch. Each approach declares its own ``option_schema`` so the CLI's
+``--approach-option`` flag can validate and coerce values, and so
+unsupported knobs warn instead of being silently dropped (the prior
+behaviour for e.g. ``--use-slicing`` on ``raw-sast``).
+
+Required dependencies on common LLM kwargs (``provider``, ``model``,
+``dry_run``) are passed positionally via the shared ``LLMConfig`` dataclass
+in this module, not through the option schema — they aren't per-approach
+toggles, they're invocation context.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+from benchmarks.adapters.ground_truth import GroundTruthEntry
+from benchmarks.adapters.registry import OptionSpec, _to_bool
+from benchmarks.approaches.base import BenchmarkApproach, BenchmarkResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LLMConfig:
+    """Invocation-time LLM context shared by every LLM-backed approach.
+
+    Approaches that aren't LLM-backed (``raw-sast``) ignore this and the
+    registry doesn't require them to accept it.
+    """
+
+    provider: str = "openai"
+    model: str = "gpt-4o"
+    dry_run: bool = False
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+class RegisteredApproach(BenchmarkApproach, ABC):
+    """Base for registry-aware approaches.
+
+    Subclass ``BenchmarkApproach`` so the ABC ``.evaluate()`` contract is
+    still enforced. Adds class-level metadata read by the registry.
+    """
+
+    # ── Class-level metadata (override in subclasses) ──
+    name: ClassVar[str] = ""
+    requires_llm: ClassVar[bool] = True
+    is_baseline: ClassVar[bool] = False  # raw-sast = True; LLM approaches = False
+    option_schema: ClassVar[dict[str, OptionSpec]] = {}
+
+    @classmethod
+    @abstractmethod
+    def from_options(
+        cls,
+        llm: LLMConfig | None,
+        options: dict[str, Any],
+    ) -> RegisteredApproach:
+        """Construct an instance from validated CLI options.
+
+        Each subclass picks the options it cares about. Unknown keys are
+        already filtered by the dispatcher (see ``build_approach`` below).
+        """
+        ...
+
+
+_REGISTRY: dict[str, type[RegisteredApproach]] = {}
+
+
+def register_approach(cls: type[RegisteredApproach]) -> type[RegisteredApproach]:
+    """Decorator: register a RegisteredApproach subclass by its ``name``."""
+    if not issubclass(cls, RegisteredApproach):
+        raise TypeError(f"{cls!r} must inherit RegisteredApproach")
+    if not cls.name:
+        raise ValueError(f"{cls.__name__} must declare a non-empty class attr 'name'")
+    if cls.name in _REGISTRY and _REGISTRY[cls.name] is not cls:
+        raise ValueError(
+            f"duplicate approach registration for name {cls.name!r}: "
+            f"{_REGISTRY[cls.name].__name__} vs {cls.__name__}"
+        )
+    _REGISTRY[cls.name] = cls
+    return cls
+
+
+def get_approach(name: str) -> type[RegisteredApproach]:
+    """Resolve a name to an approach class. Raises ``KeyError`` on miss."""
+    _ensure_loaded()
+    try:
+        return _REGISTRY[name]
+    except KeyError as exc:
+        raise KeyError(
+            f"unknown approach {name!r}; registered: {sorted(_REGISTRY)}"
+        ) from exc
+
+
+def all_approach_names() -> list[str]:
+    """All registered approach names, sorted."""
+    _ensure_loaded()
+    return sorted(_REGISTRY)
+
+
+def coerce_approach_options(
+    name: str, options: dict[str, Any]
+) -> tuple[dict[str, Any], list[str]]:
+    """Validate and coerce options against the approach's ``option_schema``."""
+    cls = get_approach(name)
+    valid: dict[str, Any] = {}
+    ignored: list[str] = []
+    for key, raw in options.items():
+        spec = cls.option_schema.get(key)
+        if spec is None:
+            ignored.append(key)
+            continue
+        try:
+            valid[key] = spec.coerce(raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"option {key}={raw!r} for approach {name!r}: {exc}"
+            ) from exc
+    return valid, ignored
+
+
+def build_approach(
+    name: str,
+    llm: LLMConfig | None = None,
+    options: dict[str, Any] | None = None,
+) -> RegisteredApproach:
+    """Single entry point: resolve approach, coerce options, instantiate."""
+    cls = get_approach(name)
+    valid, ignored = coerce_approach_options(name, options or {})
+    if ignored:
+        logger.warning(
+            "ignored unknown options for approach %s: %s "
+            "(valid keys: %s)",
+            name,
+            ignored,
+            sorted(cls.option_schema),
+        )
+    return cls.from_options(llm, valid)
+
+
+_LOADED = False
+
+
+def _ensure_loaded() -> None:
+    global _LOADED
+    if _LOADED:
+        return
+    _LOADED = True
+    for modname in (
+        "benchmarks.approaches.raw_sast",
+        "benchmarks.approaches.vulnhunterx",
+        "benchmarks.approaches.ablation",
+    ):
+        try:
+            __import__(modname)
+        except Exception:  # noqa: BLE001
+            logger.warning("failed to import approach module %s", modname, exc_info=True)
+
+
+__all__ = [
+    "LLMConfig",
+    "RegisteredApproach",
+    "register_approach",
+    "get_approach",
+    "all_approach_names",
+    "coerce_approach_options",
+    "build_approach",
+    "_to_bool",
+    "OptionSpec",
+    "BenchmarkResult",
+    "GroundTruthEntry",
+]

--- a/benchmarks/approaches/vulnhunterx.py
+++ b/benchmarks/approaches/vulnhunterx.py
@@ -8,19 +8,26 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
+from typing import Any
+
 from vuln_hunter_x.context.snippet_provider import SnippetContextProvider
 from vuln_hunter_x.core.config import Config
 from vuln_hunter_x.questions.loader import QuestionsLoader
 from vuln_hunter_x.verification.engine import VerificationEngine
 
 from benchmarks.adapters.ground_truth import GroundTruthEntry
+from benchmarks.adapters.registry import OptionSpec, _to_bool
 from benchmarks.approaches.base import (
-    BenchmarkApproach,
     BenchmarkResult,
     _SnippetContextExtractor,
     _dry_run_result,
     entry_to_finding,
     verdict_to_pred,
+)
+from benchmarks.approaches.registry import (
+    LLMConfig,
+    RegisteredApproach,
+    register_approach,
 )
 
 # Default prompts directory containing all per-language *_questions.yaml files
@@ -29,7 +36,8 @@ _PROMPTS_DIR = (
 )
 
 
-class VulnHunterXApproach(BenchmarkApproach):
+@register_approach
+class VulnHunterXApproach(RegisteredApproach):
     """Approach 4 — the system under test.
 
     Uses the full VulnHunterX pipeline:
@@ -38,6 +46,39 @@ class VulnHunterXApproach(BenchmarkApproach):
     """
 
     name = "vulnhunterx"
+    requires_llm = True
+    is_baseline = False
+    option_schema = {
+        "max_iterations": OptionSpec(
+            int,
+            default=3,
+            help="Max LLM turns per finding.",
+        ),
+        "force_decision": OptionSpec(
+            _to_bool,
+            default=True,
+            help="If True, force a TP/FP verdict after max_iterations (no NMD).",
+        ),
+        "use_slicing": OptionSpec(
+            _to_bool,
+            default=False,
+            help="Use variable-aware code slicing instead of full snippet.",
+        ),
+    }
+
+    @classmethod
+    def from_options(
+        cls, llm: LLMConfig | None, options: dict[str, Any]
+    ) -> "VulnHunterXApproach":
+        llm = llm or LLMConfig()
+        return cls(
+            provider=llm.provider,
+            model=llm.model,
+            dry_run=llm.dry_run,
+            max_iterations=options.get("max_iterations", 3),
+            force_decision=options.get("force_decision", True),
+            use_slicing=options.get("use_slicing", False),
+        )
 
     def __init__(
         self,

--- a/benchmarks/datasets.yaml
+++ b/benchmarks/datasets.yaml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 VinSOC Cyber
+#
+# Single source of truth for benchmark dataset install metadata.
+# Read by:
+#   - benchmarks/scripts/setup_datasets.py (download + extract)
+#   - benchmarks/scripts/run_benchmark.py  (dataset-name resolution
+#     happens via the adapter registry, but `dirname` overrides for
+#     on-disk path quirks like the "owasp-benchmark-" prefix)
+#
+# Adding a new dataset:
+#   1. Implement the adapter (inherit DatasetAdapter, self-register).
+#   2. Add an entry here with install info.
+#   No edits to run_benchmark.py or setup_datasets.py are needed.
+
+datasets:
+  secllmholmes:
+    description: "SecLLMHolmes: 228 C/C++ & Python scenarios (8 CWE classes)"
+    type: git
+    url: "https://github.com/ai4cloudops/SecLLMHolmes"
+    dirname: secllmholmes
+    disk_mb: 50
+
+  juliet:
+    description: "Juliet C/C++ 1.3.1: 64K test cases across ~180 CWEs (NIST SARD)"
+    type: zip
+    url: "https://samate.nist.gov/SARD/downloads/test-suites/2017-10-01-juliet-test-suite-for-c-cplusplus-v1-3.zip"
+    dirname: juliet
+    disk_mb: 600
+
+  owasp-java:
+    description: "OWASP BenchmarkJava v1.2: ~2,740 Java test cases, 11 CWE categories (GPL-2.0)"
+    type: git
+    url: "https://github.com/OWASP-Benchmark/BenchmarkJava"
+    dirname: owasp-benchmark-java
+    disk_mb: 200
+
+  owasp-python:
+    description: "OWASP BenchmarkPython v0.1: ~1,230 Python test cases (GPL-3.0)"
+    type: git
+    url: "https://github.com/OWASP-Benchmark/BenchmarkPython"
+    dirname: owasp-benchmark-python
+    disk_mb: 80
+
+  realvuln:
+    description: "RealVuln Benchmark: real-CVE TPs + FP traps across Python web frameworks (MIT)"
+    type: git
+    url: "https://github.com/kolega-ai/Real-Vuln-Benchmark"
+    dirname: realvuln
+    disk_mb: 30
+
+  diversevul:
+    description: "DiverseVul: 349K C/C++ functions with real CVE-backed labels (150 CWEs)"
+    type: gdrive
+    gdrive_id: "12IWKhmLhq7qn5B_iXgn5YerOQtkH-6RG"
+    filename: diversevul.json
+    dirname: diversevul
+    disk_mb: 2000

--- a/benchmarks/scripts/generate_report.py
+++ b/benchmarks/scripts/generate_report.py
@@ -141,13 +141,30 @@ def _run_metadata(run_dir: Path, summaries: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _is_baseline(approach_name: str) -> bool:
+    """Return True if the approach is a non-LLM baseline.
+
+    Consults the approach registry's ``is_baseline`` class attribute when
+    available; falls back to the historic string match on ``"raw-sast"``
+    if the registry can't be queried (e.g. summary loaded from a JSON
+    whose approach name isn't registered in this checkout).
+    """
+    try:
+        from benchmarks.approaches.registry import get_approach
+        return get_approach(approach_name).is_baseline
+    except (KeyError, ImportError):
+        return approach_name == "raw-sast"
+
+
 def _key_findings(summaries: list[dict]) -> str:
     """Auto-generate a Key Findings prose section from the summary data."""
     if not summaries:
         return ""
 
-    llm_summaries = [s for s in summaries if s.get("approach") != "raw-sast"]
-    next((s for s in summaries if s.get("approach") == "raw-sast"), None)
+    llm_summaries = [
+        s for s in summaries if not _is_baseline(s.get("approach", ""))
+    ]
+    next((s for s in summaries if _is_baseline(s.get("approach", ""))), None)
 
     bullets: list[str] = []
 
@@ -722,7 +739,7 @@ def _generate_charts(summaries: list[dict], out_dir: Path) -> list[tuple[str, st
     # ── Chart 2: F1 Score comparison ──────────────────────────────────────────
     f1_vals = [(s.get("f1") or 0) * 100 for s in summaries]
     fig, ax = plt.subplots(figsize=(max(6, len(approaches) * 1.5), 5))
-    colors = ["#4C72B0" if a != "raw-sast" else "#8c8c8c" for a in approaches]
+    colors = ["#4C72B0" if not _is_baseline(a) else "#8c8c8c" for a in approaches]
     bars = ax.bar(x, f1_vals, color=colors)
     ax.bar_label(bars, fmt="%.1f%%", padding=3, fontsize=9)
     ax.set_xticks(x)
@@ -741,7 +758,7 @@ def _generate_charts(summaries: list[dict], out_dir: Path) -> list[tuple[str, st
     fp_vals = [(s.get("fp_reduction_rate") or 0) * 100 for s in summaries]
     tp_vals = [(s.get("tp_preservation_rate") or 0) * 100 for s in summaries]
     fig, ax = plt.subplots(figsize=(7, 6))
-    scatter_colors = ["#8c8c8c" if a == "raw-sast" else "#4C72B0" for a in approaches]
+    scatter_colors = ["#8c8c8c" if _is_baseline(a) else "#4C72B0" for a in approaches]
     ax.scatter(fp_vals, tp_vals, c=scatter_colors, s=120, zorder=3)
     for i, label in enumerate(approaches):
         ax.annotate(label, (fp_vals[i], tp_vals[i]),
@@ -821,7 +838,10 @@ def _generate_charts(summaries: list[dict], out_dir: Path) -> list[tuple[str, st
         logger.info("Chart saved: %s", p)
 
     # ── Chart 5: Latency comparison ───────────────────────────────────────────
-    llm_s = [s for s in summaries if s.get("approach") != "raw-sast" and (s.get("mean_latency_s") or 0) > 0]
+    llm_s = [
+        s for s in summaries
+        if not _is_baseline(s.get("approach", "")) and (s.get("mean_latency_s") or 0) > 0
+    ]
     if llm_s:
         llm_approaches = [s.get("approach", "?") for s in llm_s]
         mean_lats = [s.get("mean_latency_s") or 0 for s in llm_s]

--- a/benchmarks/scripts/run_benchmark.py
+++ b/benchmarks/scripts/run_benchmark.py
@@ -39,6 +39,8 @@ Usage examples:
 from __future__ import annotations
 
 import argparse
+import warnings
+from typing import Any
 import json
 import logging
 import os
@@ -148,86 +150,90 @@ def _load_fixture(
     return entries
 
 
-def _load_dataset(name: str, limit: int, juliet_per_cwe: int = 20, langs: list[str] | None = None, cwes: list[str] | None = None, include_unknown_cwe: bool = False, diversevul_negative_fraction: float | None = None) -> list[GroundTruthEntry]:
-    """Load entries for a given dataset name."""
-    # Check for fixture files first (for smoke tests)
+def _parse_kv_options(items: list[str] | None) -> dict[str, str]:
+    """Parse ``KEY=VALUE`` strings from ``action="append"`` argparse args.
+
+    Returns a dict mapping key -> raw string value (further coercion happens
+    inside the registry's ``option_schema``). A bare key with no ``=`` is
+    treated as ``key=true`` so flag-shaped options stay convenient.
+    """
+    result: dict[str, str] = {}
+    for raw in items or []:
+        if "=" in raw:
+            key, _, value = raw.partition("=")
+        else:
+            key, value = raw, "true"
+        key = key.strip()
+        if not key:
+            continue
+        result[key] = value.strip()
+    return result
+
+
+# Dataset on-disk directory mapping is read from benchmarks/datasets.yaml
+# (the single source of truth shared with setup_datasets.py). If the
+# manifest is missing or a dataset isn't listed, we fall back to using
+# the registered name as the directory name.
+_MANIFEST_PATH = _REPO_ROOT / "benchmarks" / "datasets.yaml"
+_DATASET_DIRNAMES: dict[str, str] = {}
+if _MANIFEST_PATH.is_file():
+    try:
+        import yaml as _yaml
+        _raw = _yaml.safe_load(_MANIFEST_PATH.read_text(encoding="utf-8")) or {}
+        _DATASET_DIRNAMES = {
+            n: cfg["dirname"]
+            for n, cfg in (_raw.get("datasets") or {}).items()
+            if "dirname" in cfg
+        }
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to load benchmark dataset manifest", exc_info=True)
+
+
+def _resolve_dataset_path(name: str) -> Path:
+    return DATASETS_DIR / _DATASET_DIRNAMES.get(name, name)
+
+
+def _load_dataset(
+    name: str,
+    limit: int,
+    options: dict[str, Any] | None = None,
+    langs: list[str] | None = None,
+    fallback_cwes: list[str] | None = None,
+) -> list[GroundTruthEntry]:
+    """Load entries for a given dataset name via the registry.
+
+    Falls back to a fixture file under ``benchmarks/fixtures/`` if the
+    dataset has not been downloaded. The ``options`` dict is validated
+    against the adapter's ``option_schema`` by ``load_dataset()``; unknown
+    keys produce a warning.
+    """
+    from benchmarks.adapters.registry import get_adapter, load_dataset
+
+    options = dict(options or {})
+    ds_path = _resolve_dataset_path(name)
     fixture = _REPO_ROOT / "benchmarks" / "fixtures" / f"{name}_sample.json"
 
-    if name == "secllmholmes":
-        ds_path = DATASETS_DIR / "secllmholmes"
-        if ds_path.exists():
-            from benchmarks.adapters.secllmholmes_adapter import SecLLMHolmesAdapter
-            return SecLLMHolmesAdapter(ds_path).load(limit=limit)
-        if fixture.exists():
-            return _load_fixture(fixture, limit=limit, langs=langs, cwes=cwes)
-        raise FileNotFoundError(
-            f"SecLLMHolmes dataset not found at {ds_path}. "
-            "Run: python benchmarks/scripts/setup_datasets.py --dataset secllmholmes"
-        )
+    if ds_path.exists():
+        return load_dataset(name, ds_path, limit=limit, options=options)
 
-    if name == "juliet":
-        ds_path = DATASETS_DIR / "juliet"
-        if ds_path.exists():
-            from benchmarks.adapters.juliet_adapter import JulietAdapter
-            return JulietAdapter(ds_path).load(
-                mode="offline",
-                limit=limit,
-                per_cwe_limit=juliet_per_cwe,
-                benchmark_cwes_only=(juliet_per_cwe > 0),
-            )
-        if fixture.exists():
-            return _load_fixture(fixture, limit=limit, langs=langs, cwes=cwes)
-        raise FileNotFoundError(
-            f"Juliet dataset not found at {ds_path}. "
-            "Run: python benchmarks/scripts/setup_datasets.py --dataset juliet"
-        )
+    if fixture.exists():
+        return _load_fixture(fixture, limit=limit, langs=langs, cwes=fallback_cwes)
 
-    if name == "realvuln":
-        ds_path = DATASETS_DIR / "realvuln"
-        if ds_path.exists():
-            from benchmarks.adapters.realvuln_adapter import RealVulnAdapter
-            return RealVulnAdapter(ds_path).load(limit=limit)
-        if fixture.exists():
-            return _load_fixture(fixture, limit=limit, langs=langs, cwes=cwes)
-        raise FileNotFoundError(
-            f"RealVuln dataset not found at {ds_path}. "
-            "Run: python benchmarks/scripts/setup_datasets.py --dataset realvuln"
-        )
-
-    if name in ("owasp-java", "owasp-python"):
-        lang = "java" if name == "owasp-java" else "python"
-        ds_path = DATASETS_DIR / f"owasp-benchmark-{lang}"
-        if ds_path.exists():
-            from benchmarks.adapters.owasp_benchmark_adapter import OwaspBenchmarkAdapter
-            return OwaspBenchmarkAdapter(ds_path, lang=lang).load(limit=limit)
-        if fixture.exists():
-            return _load_fixture(fixture, limit=limit, langs=langs, cwes=cwes)
-        # Fall back to the shared owasp_benchmark fixture if specific one absent
+    # OWASP variants share a single bundled fixture
+    if name.startswith("owasp-"):
         shared = _REPO_ROOT / "benchmarks" / "fixtures" / "owasp_benchmark_sample.json"
         if shared.exists():
-            entries = _load_fixture(shared, limit=0, langs=[lang], cwes=cwes)
+            lang = name.split("-", 1)[1]
+            entries = _load_fixture(shared, limit=0, langs=[lang], cwes=fallback_cwes)
             return entries[: limit or len(entries)]
-        raise FileNotFoundError(
-            f"OWASP Benchmark dataset not found at {ds_path}. "
-            f"Run: python benchmarks/scripts/setup_datasets.py --dataset {name}"
-        )
 
-    if name == "diversevul":
-        ds_path = DATASETS_DIR / "diversevul"
-        if ds_path.exists():
-            from benchmarks.adapters.diversevul_adapter import DiverseVulAdapter
-            return DiverseVulAdapter(ds_path).load(
-                limit=limit, cwes=cwes, include_unknown_cwe=include_unknown_cwe,
-                negative_fraction=diversevul_negative_fraction,
-            )
-        if fixture.exists():
-            return _load_fixture(fixture, limit=limit, langs=langs, cwes=cwes)
-        raise FileNotFoundError(
-            f"DiverseVul dataset not found at {ds_path}. "
-            "Download from: https://github.com/wagner-group/diversevul"
-        )
-
-    raise ValueError(f"Unknown dataset: {name!r}")
+    # Touch the adapter to surface a clean KeyError if the name is unknown
+    # before reporting a missing-dataset error.
+    get_adapter(name)
+    raise FileNotFoundError(
+        f"Dataset {name!r} not found at {ds_path}. "
+        f"Run: python benchmarks/scripts/setup_datasets.py --dataset {name}"
+    )
 
 
 # ── Approach factory ─────────────────────────────────────────────────────────
@@ -236,22 +242,24 @@ def _build_approach(
     name: str,
     model: str,
     provider: str,
-    max_iterations: int,
     dry_run: bool,
-    force_decision: bool = True,
-    use_slicing: bool = False,
+    options: dict[str, Any] | None = None,
 ) -> BenchmarkApproach:
-    common = {"provider": provider, "model": model, "dry_run": dry_run}
-    if name == "raw-sast":
-        return RawSastApproach()
-    if name == "vulnhunterx":
-        return VulnHunterXApproach(
-            **common, max_iterations=max_iterations,
-            force_decision=force_decision, use_slicing=use_slicing,
-        )
-    if name == "ablation":
-        return AblationApproach(**common, max_iterations=max_iterations)
-    raise ValueError(f"Unknown approach: {name!r}")
+    """Construct an approach instance via the registry.
+
+    Per-approach knobs (``max_iterations``, ``force_decision``,
+    ``use_slicing``) live in ``options`` and are validated against the
+    approach's ``option_schema``. Unknown options for the chosen approach
+    produce a warning, not a crash — see ``build_approach`` in the
+    approach registry.
+    """
+    from benchmarks.approaches.registry import LLMConfig, build_approach
+
+    return build_approach(
+        name,
+        llm=LLMConfig(provider=provider, model=model, dry_run=dry_run),
+        options=options or {},
+    )
 
 
 # ── Checkpoint helpers ────────────────────────────────────────────────────────
@@ -672,20 +680,30 @@ def main() -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
+    # ``--dataset`` and ``--approach`` accept any name registered with the
+    # respective registry, plus ``all`` and family tags (e.g. ``owasp``).
+    # No closed ``choices`` list — keeping the parser open lets a newly-
+    # added adapter or approach work without editing this file.
+    from benchmarks.adapters.registry import all_adapter_names
+    from benchmarks.approaches.registry import all_approach_names
+
+    _adapter_names = all_adapter_names()
+    _approach_names = all_approach_names()
     parser.add_argument(
         "--dataset",
-        choices=["secllmholmes", "juliet", "diversevul",
-                 "owasp-java", "owasp-python", "owasp",
-                 "realvuln", "all"],
         default="secllmholmes",
+        metavar="DATASET",
+        help=(
+            f"Dataset name: one of {_adapter_names!r}, a family tag, or "
+            f"'all'. (Adapters auto-discovered from the registry.)"
+        ),
     )
     parser.add_argument(
         "--approach",
         nargs="+",
-        choices=["raw-sast", "vulnhunterx", "ablation", "all"],
         default=["all"],
         metavar="APPROACH",
-        help="One or more of: raw-sast vulnhunterx ablation all",
+        help=f"One or more of: {' '.join(_approach_names)} all",
     )
     parser.add_argument("--model", default=os.environ.get("LLM_MODEL", "gpt-4o"))
     parser.add_argument("--provider", default=os.environ.get("LLM_PROVIDER", "openai"))
@@ -746,7 +764,35 @@ def main() -> int:
         ),
     )
     parser.add_argument("--max-iterations", type=int, default=_DEFAULT_MAX_ITERATIONS,
-                        help=f"Max iterations for multi-turn approaches (default: {_DEFAULT_MAX_ITERATIONS}, from benchmarks/config/benchmark.yaml)")
+                        help=f"Max iterations for multi-turn approaches (default: {_DEFAULT_MAX_ITERATIONS}, from benchmarks/config/benchmark.yaml). "
+                             "Deprecated; prefer --approach-option max_iterations=N.")
+    parser.add_argument(
+        "--dataset-option",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Set a dataset-adapter option (repeatable). The key is "
+            "validated against the chosen dataset's option_schema; "
+            "unknown keys warn. Examples: "
+            "--dataset-option negative_fraction=0.5 (diversevul), "
+            "--dataset-option per_cwe_limit=20 (juliet), "
+            "--dataset-option include_unknown_cwe=true (diversevul)."
+        ),
+    )
+    parser.add_argument(
+        "--approach-option",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Set an approach option (repeatable). Validated against the "
+            "chosen approach's option_schema. Examples: "
+            "--approach-option max_iterations=4 (vulnhunterx/ablation), "
+            "--approach-option force_decision=false (vulnhunterx), "
+            "--approach-option use_slicing=true (vulnhunterx)."
+        ),
+    )
     parser.add_argument(
         "--nmd-handling",
         choices=["exclude", "fp"],
@@ -896,17 +942,24 @@ def main() -> int:
     except Exception:
         pass
 
-    # Determine datasets and approaches
+    # Determine datasets and approaches via the registries.
+    # ``all`` expands to every registered adapter. A family tag (e.g.
+    # ``owasp``) expands to every adapter whose ``family`` attribute
+    # matches — discovered from the registry, not hard-coded. A specific
+    # adapter name is used as-is.
+    from benchmarks.adapters.registry import (
+        adapters_in_family,
+        all_adapter_names,
+    )
+    from benchmarks.approaches.registry import all_approach_names
+
     if args.dataset == "all":
-        datasets = ["secllmholmes", "juliet", "diversevul",
-                    "owasp-java", "owasp-python", "realvuln"]
-    elif args.dataset == "owasp":
-        datasets = ["owasp-java", "owasp-python"]
+        datasets = all_adapter_names()
     else:
-        datasets = [args.dataset]
-    _ALL_APPROACHES = ["raw-sast", "vulnhunterx", "ablation"]
+        family_expansion = adapters_in_family(args.dataset)
+        datasets = family_expansion if family_expansion else [args.dataset]
     approaches = (
-        _ALL_APPROACHES
+        all_approach_names()
         if "all" in args.approach
         else list(dict.fromkeys(args.approach))
     )
@@ -1011,11 +1064,56 @@ def main() -> int:
             args.limit,
         )
 
+    # Merge --dataset-option / --approach-option KEY=VALUE entries (free-
+    # form) with deprecated per-dataset / per-approach flags. The
+    # deprecated flags still work for one release but emit a warning and
+    # only apply to the target they were originally scoped to.
+    user_dataset_options = _parse_kv_options(args.dataset_option)
+    user_approach_options = _parse_kv_options(args.approach_option)
+
+    def _options_for_dataset(name: str) -> dict[str, Any]:
+        opts: dict[str, Any] = dict(user_dataset_options)
+        if name == "diversevul":
+            if args.include_unknown_cwe and "include_unknown_cwe" not in opts:
+                warnings.warn(
+                    "--include-unknown-cwe is deprecated; use "
+                    "--dataset-option include_unknown_cwe=true",
+                    DeprecationWarning, stacklevel=2,
+                )
+                opts["include_unknown_cwe"] = True
+            if (args.diversevul_negative_fraction is not None
+                    and "negative_fraction" not in opts):
+                warnings.warn(
+                    "--diversevul-negative-fraction is deprecated; use "
+                    "--dataset-option negative_fraction=<float>",
+                    DeprecationWarning, stacklevel=2,
+                )
+                opts["negative_fraction"] = args.diversevul_negative_fraction
+            if args.cwe and "cwes" not in opts:
+                opts["cwes"] = list(args.cwe)
+        elif name == "juliet":
+            if "per_cwe_limit" not in opts and args.juliet_per_cwe != 20:
+                warnings.warn(
+                    "--juliet-per-cwe is deprecated; use "
+                    "--dataset-option per_cwe_limit=N",
+                    DeprecationWarning, stacklevel=2,
+                )
+                opts["per_cwe_limit"] = args.juliet_per_cwe
+            opts.setdefault("per_cwe_limit", args.juliet_per_cwe)
+            opts.setdefault("benchmark_cwes_only", args.juliet_per_cwe > 0)
+        return opts
+
     try:
         for dataset_name in datasets:
             logger.info("Loading dataset: %s (limit=%d)", dataset_name, args.limit)
             try:
-                entries = _load_dataset(dataset_name, args.limit, juliet_per_cwe=args.juliet_per_cwe, langs=args.lang, cwes=args.cwe, include_unknown_cwe=args.include_unknown_cwe, diversevul_negative_fraction=args.diversevul_negative_fraction)
+                entries = _load_dataset(
+                    dataset_name,
+                    args.limit,
+                    options=_options_for_dataset(dataset_name),
+                    langs=args.lang,
+                    fallback_cwes=args.cwe,
+                )
             except FileNotFoundError as exc:
                 logger.error("%s", exc)
                 continue
@@ -1044,14 +1142,34 @@ def main() -> int:
                         if args.iteration_sweep
                         else approach_name
                     )
+                    approach_options = dict(user_approach_options)
+                    # Deprecation shims: the historic CLI flags still set
+                    # these options unless the user passed them explicitly
+                    # via --approach-option. We only propagate options the
+                    # chosen approach actually declares — otherwise raw-sast
+                    # (which has an empty option_schema) would spam warnings
+                    # for every default flag value.
+                    from benchmarks.approaches.registry import get_approach
+                    schema = get_approach(approach_name).option_schema
+                    if "max_iterations" in schema:
+                        approach_options.setdefault("max_iterations", max_iters)
+                    if (
+                        "force_decision" in schema
+                        and "force_decision" not in approach_options
+                    ):
+                        approach_options["force_decision"] = args.force_decision
+                    if (
+                        "use_slicing" in schema
+                        and args.sliced_context
+                        and "use_slicing" not in approach_options
+                    ):
+                        approach_options["use_slicing"] = True
                     approach = _build_approach(
                         approach_name,
                         args.model,
                         args.provider,
-                        max_iters,
                         args.dry_run,
-                        force_decision=args.force_decision,
-                        use_slicing=args.sliced_context,
+                        options=approach_options,
                     )
                     approach.name = effective_name
 

--- a/benchmarks/scripts/setup_datasets.py
+++ b/benchmarks/scripts/setup_datasets.py
@@ -18,58 +18,34 @@ import sys
 import urllib.request
 from pathlib import Path
 
+import yaml
+
 logging.basicConfig(level=logging.INFO, format="%(levelname)s  %(message)s")
 logger = logging.getLogger(__name__)
 
-DATASETS_DIR = Path(__file__).resolve().parents[1] / "datasets"
+_BENCHMARKS_DIR = Path(__file__).resolve().parents[1]
+DATASETS_DIR = _BENCHMARKS_DIR / "datasets"
+_MANIFEST_PATH = _BENCHMARKS_DIR / "datasets.yaml"
 
-# Dataset configurations
-DATASETS: dict[str, dict] = {
-    "secllmholmes": {
-        "description": "SecLLMHolmes: 228 C/C++ & Python scenarios (8 CWE classes)",
-        "type": "git",
-        "url": "https://github.com/ai4cloudops/SecLLMHolmes",
-        "target_dir": DATASETS_DIR / "secllmholmes",
-        "disk_mb": 50,
-    },
-    "juliet": {
-        "description": "Juliet C/C++ 1.3.1: 64K test cases across ~180 CWEs (NIST SARD)",
-        "type": "zip",
-        "url": "https://samate.nist.gov/SARD/downloads/test-suites/2017-10-01-juliet-test-suite-for-c-cplusplus-v1-3.zip",
-        "target_dir": DATASETS_DIR / "juliet",
-        "disk_mb": 600,
-    },
-    "owasp-java": {
-        "description": "OWASP BenchmarkJava v1.2: ~2,740 Java test cases, 11 CWE categories (GPL-2.0)",
-        "type": "git",
-        "url": "https://github.com/OWASP-Benchmark/BenchmarkJava",
-        "target_dir": DATASETS_DIR / "owasp-benchmark-java",
-        "disk_mb": 200,
-    },
-    "owasp-python": {
-        "description": "OWASP BenchmarkPython v0.1: ~1,230 Python test cases (GPL-3.0)",
-        "type": "git",
-        "url": "https://github.com/OWASP-Benchmark/BenchmarkPython",
-        "target_dir": DATASETS_DIR / "owasp-benchmark-python",
-        "disk_mb": 80,
-    },
-    "realvuln": {
-        "description": "RealVuln Benchmark: real-CVE TPs + FP traps across Python web frameworks (MIT). Substitute for SastBench (URL not findable).",
-        "type": "git",
-        "url": "https://github.com/kolega-ai/Real-Vuln-Benchmark",
-        "target_dir": DATASETS_DIR / "realvuln",
-        "disk_mb": 30,
-    },
-    "diversevul": {
-        "description": "DiverseVul: 349K C/C++ functions with real CVE-backed labels (150 CWEs)",
-        "type": "gdrive",
-        # Google Drive file ID from https://github.com/wagner-group/diversevul README
-        "gdrive_id": "12IWKhmLhq7qn5B_iXgn5YerOQtkH-6RG",
-        "filename": "diversevul.json",
-        "target_dir": DATASETS_DIR / "diversevul",
-        "disk_mb": 2000,
-    },
-}
+
+def _load_manifest() -> dict[str, dict]:
+    """Load the install manifest from datasets.yaml and resolve target_dir.
+
+    The manifest stores ``dirname`` (the on-disk directory name); we
+    compute ``target_dir`` from it relative to ``DATASETS_DIR``. This
+    keeps the YAML free of absolute paths.
+    """
+    with _MANIFEST_PATH.open(encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh) or {}
+    out: dict[str, dict] = {}
+    for name, cfg in (raw.get("datasets") or {}).items():
+        resolved = dict(cfg)
+        resolved["target_dir"] = DATASETS_DIR / cfg["dirname"]
+        out[name] = resolved
+    return out
+
+
+DATASETS: dict[str, dict] = _load_manifest()
 
 
 def _git_clone(url: str, target: Path) -> None:

--- a/tests/test_registry_contract.py
+++ b/tests/test_registry_contract.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 VinSOC Cyber
+
+"""Contract tests for the dataset-adapter and benchmark-approach registries.
+
+Both registries replace if/else dispatch chains in
+``benchmarks/scripts/run_benchmark.py``. These tests iterate the registry
+(not a hard-coded list of names) and assert each registered class
+satisfies its respective ABC. Adding a new adapter/approach automatically
+expands the test surface — no separate test PR required.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from benchmarks.adapters.registry import (
+    DatasetAdapter,
+    OptionSpec,
+    _to_bool,
+    _to_csv_list,
+    all_adapter_names,
+    coerce_options,
+    get_adapter,
+    load_dataset,
+    register_adapter,
+)
+from benchmarks.approaches.registry import (
+    LLMConfig,
+    RegisteredApproach,
+    all_approach_names,
+    build_approach,
+    coerce_approach_options,
+    get_approach,
+    register_approach,
+)
+from benchmarks.approaches.base import BenchmarkResult
+
+
+# ── Adapter contract ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", all_adapter_names())
+def test_adapter_inherits_abc(name: str):
+    cls = get_adapter(name)
+    assert issubclass(cls, DatasetAdapter), f"{cls.__name__} must inherit DatasetAdapter"
+
+
+@pytest.mark.parametrize("name", all_adapter_names())
+def test_adapter_declares_metadata(name: str):
+    cls = get_adapter(name)
+    assert cls.name == name, f"{cls.__name__}.name {cls.name!r} != registry key {name!r}"
+    assert isinstance(cls.langs, tuple) and cls.langs, (
+        f"{cls.__name__}.langs must be a non-empty tuple"
+    )
+    assert isinstance(cls.option_schema, dict), (
+        f"{cls.__name__}.option_schema must be a dict"
+    )
+
+
+@pytest.mark.parametrize("name", all_adapter_names())
+def test_adapter_option_specs_are_well_formed(name: str):
+    """Every option in option_schema must be an OptionSpec with a callable coerce."""
+    cls = get_adapter(name)
+    for opt_name, spec in cls.option_schema.items():
+        assert isinstance(spec, OptionSpec), (
+            f"{cls.__name__}.option_schema[{opt_name!r}] must be an OptionSpec"
+        )
+        assert callable(spec.coerce), (
+            f"{cls.__name__}.option_schema[{opt_name!r}].coerce must be callable"
+        )
+
+
+def test_adapter_registry_rejects_duplicate():
+    """Re-registering the same class is a no-op; re-registering a DIFFERENT
+    class under an existing name raises. Locks the deduplication invariant."""
+
+    class _Duplicate(DatasetAdapter):
+        name = "diversevul"  # already taken
+        langs = ("c",)
+        option_schema: dict = {}
+
+        def __init__(self, dataset_path):  # noqa: ANN001
+            self.dataset_path = dataset_path
+
+        def load(self, limit=0, **kwargs):
+            return []
+
+    with pytest.raises(ValueError, match="duplicate"):
+        register_adapter(_Duplicate)
+
+
+def test_adapter_registry_unknown_name():
+    with pytest.raises(KeyError, match="unknown dataset"):
+        get_adapter("not-a-real-dataset")
+
+
+def test_coerce_options_separates_valid_and_ignored():
+    valid, ignored = coerce_options(
+        "diversevul",
+        {"negative_fraction": "0.5", "bogus_key": "x"},
+    )
+    assert valid == {"negative_fraction": 0.5}
+    assert ignored == ["bogus_key"]
+
+
+def test_coerce_options_raises_on_bad_value():
+    with pytest.raises(ValueError):
+        coerce_options("diversevul", {"negative_fraction": "not a float"})
+
+
+def test_to_bool_and_csv_list_helpers():
+    assert _to_bool("true") is True
+    assert _to_bool("False") is False
+    assert _to_bool("1") is True
+    with pytest.raises(ValueError):
+        _to_bool("maybe")
+    assert _to_csv_list("a,b, c") == ["a", "b", "c"]
+    assert _to_csv_list("") == []
+
+
+def test_load_dataset_warns_on_unknown_option(caplog, tmp_path):
+    # Use an empty tmp dir — the adapter raises after the warning fires.
+    # We assert on the warning regardless of whether load() succeeds.
+    with caplog.at_level("WARNING"):
+        with pytest.raises(Exception):  # noqa: BLE001 — any error after the warning
+            load_dataset("diversevul", tmp_path, options={"bogus": "x"})
+    assert any("ignored" in r.message for r in caplog.records)
+
+
+# ── Approach contract ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", all_approach_names())
+def test_approach_inherits_abc(name: str):
+    cls = get_approach(name)
+    assert issubclass(cls, RegisteredApproach)
+
+
+@pytest.mark.parametrize("name", all_approach_names())
+def test_approach_declares_metadata(name: str):
+    cls = get_approach(name)
+    assert cls.name == name
+    assert isinstance(cls.is_baseline, bool)
+    assert isinstance(cls.requires_llm, bool)
+    assert isinstance(cls.option_schema, dict)
+
+
+@pytest.mark.parametrize("name", all_approach_names())
+def test_approach_option_specs_are_well_formed(name: str):
+    cls = get_approach(name)
+    for opt_name, spec in cls.option_schema.items():
+        assert isinstance(spec, OptionSpec)
+        assert callable(spec.coerce)
+
+
+@pytest.mark.parametrize("name", all_approach_names())
+def test_approach_from_options_returns_self_type(name: str):
+    """``from_options`` must return an instance of the class itself, not a
+    base class — protects against accidental ABC misuse."""
+    cls = get_approach(name)
+    inst = cls.from_options(LLMConfig(dry_run=True), {})
+    assert isinstance(inst, cls)
+
+
+def test_build_approach_warns_on_unknown_option(caplog):
+    with caplog.at_level("WARNING"):
+        inst = build_approach(
+            "raw-sast",
+            llm=LLMConfig(dry_run=True),
+            options={"max_iterations": "5"},  # unknown for raw-sast
+        )
+    assert any("ignored" in r.message for r in caplog.records)
+    # Approach still instantiates despite the warning.
+    assert inst is not None
+
+
+def test_coerce_approach_options_round_trip():
+    valid, ignored = coerce_approach_options(
+        "vulnhunterx",
+        {"max_iterations": "4", "force_decision": "false", "garbage": "x"},
+    )
+    assert valid == {"max_iterations": 4, "force_decision": False}
+    assert ignored == ["garbage"]
+
+
+# ── Family aliases (registry tags) ───────────────────────────────────
+
+
+def test_adapter_family_owasp_expands():
+    from benchmarks.adapters.registry import adapters_in_family
+    names = adapters_in_family("owasp")
+    assert "owasp-java" in names
+    assert "owasp-python" in names
+
+
+def test_adapter_family_unknown_returns_empty():
+    from benchmarks.adapters.registry import adapters_in_family
+    assert adapters_in_family("not-a-family") == []


### PR DESCRIPTION
- Introduced a registry for dataset adapters to replace hard-coded logic in run_benchmark.py and setup_datasets.py.
- Moved dataset configuration to a YAML manifest (datasets.yaml) for easier management and extensibility.
- Implemented a registry for benchmark approaches, allowing dynamic loading and validation of options.
- Updated run_benchmark.py to utilize the new registries for loading datasets and approaches, improving maintainability.
- Added contract tests for both dataset and approach registries to ensure compliance with expected interfaces and behaviors.
- Deprecated old command-line options in favor of new, more flexible options that leverage the registries.