### PR TITLE
fix: 3 critical runtime bugs --- missing import, stale symlink, relatedLocations crash

### DIFF
--- a/src/vuln_hunter_x/cli/commands.py
+++ b/src/vuln_hunter_x/cli/commands.py
@@ -763,6 +763,8 @@ def cmd_analyze(args: argparse.Namespace) -> int:
         target_repo_dir = repos_dir / lang / name
         if not target_repo_dir.exists():
             target_repo_dir.parent.mkdir(parents=True, exist_ok=True)
+            if target_repo_dir.is_symlink():
+                target_repo_dir.unlink()
             target_repo_dir.symlink_to(local_path)
         # Set filters so only this repo is analyzed
         args.repo = name
@@ -922,6 +924,8 @@ def _run_context_extraction(
         target_repo_dir = repos_dir / lang_filter / name
         if not target_repo_dir.exists():
             target_repo_dir.parent.mkdir(parents=True, exist_ok=True)
+            if target_repo_dir.is_symlink():
+                target_repo_dir.unlink()
             target_repo_dir.symlink_to(local_path)
         repo_filter = name
 
@@ -1023,6 +1027,8 @@ def cmd_verify(args: argparse.Namespace) -> int:
         target_repo_dir = repos_dir / args.lang / name
         if not target_repo_dir.exists():
             target_repo_dir.parent.mkdir(parents=True, exist_ok=True)
+            if target_repo_dir.is_symlink():
+                target_repo_dir.unlink()
             target_repo_dir.symlink_to(local_path)
         args.repo = name
 

--- a/src/vuln_hunter_x/fuzz/driver_builder.py
+++ b/src/vuln_hunter_x/fuzz/driver_builder.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+from vuln_hunter_x.core.constants import BUILD_LOG_MAX_ERROR_CHARS
+
 logger = logging.getLogger(__name__)
 
 # Max lines of stderr to keep for LLM fix (normalized)

--- a/src/vuln_hunter_x/sarif/parser.py
+++ b/src/vuln_hunter_x/sarif/parser.py
@@ -114,7 +114,10 @@ def _extract_related_locations(related_locs: list) -> list[str]:
             if uri:
                 parts.append(uri)
             if line:
-                parts[-1] = f"{parts[-1]}:{line}" if parts else str(line)
+                if parts:
+                    parts[-1] = f"{parts[-1]}:{line}"
+                else:
+                    parts.append(str(line))
             entry = parts[0] if parts else ""
             if msg:
                 entry = f"{entry}: {msg}" if entry else msg


### PR DESCRIPTION
## Summary
Three critical runtime bugs found during codebase audit.
## Changes
### 1. `driver_builder.py` — Missing import → NameError crash
`BUILD_LOG_MAX_ERROR_CHARS` used at lines 514, 515, 523 but never imported.
**Fix**: Added `from vuln_hunter_x.core.constants import BUILD_LOG_MAX_ERROR_CHARS`.
### 2. `commands.py` — Stale symlink → FileExistsError
`--local-path` flow checks `exists()` before `symlink_to()`, but `Path.exists()` returns `False` for broken symlinks while `symlink_to()` still raises `FileExistsError`. Blocks re-runs after prior failure.
**Fix**: Added `is_symlink()` check + `unlink()` before `symlink_to()` at all 3 sites.
### 3. `sarif/parser.py` — IndexError in `_extract_related_locations`
When a SARIF related location has `startLine` but no `uri`, `parts[-1] = ...` crashed on empty list.
**Fix**: Guard with `if parts` before indexing; append to list when empty.