### PR TITLE
Add benchmark fixtures and scripts for model comparison

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -42,16 +42,28 @@ The design rationale, papers reviewed, and dataset selection criteria are in [RE
 
 ## Datasets
 
+Two tracks (see [RESEARCH.md § 6](RESEARCH.md#6-dataset-selection-guide--what-to-benchmark-on-and-why)).
+**Track 1 — FP-reduction** (finding-shaped: real SAST alert + TP/FP label):
+
 | Dataset                  | Size           | Language       | Ground Truth                                                                                |
 | ------------------------ | -------------- | -------------- | ------------------------------------------------------------------------------------------- |
+| **OpenVuln / ZeroFalse** | 58 alerts      | Java           | Real **CodeQL alerts** with human TP/FP labels, 7 projects — MIT (best real-world fit)      |
 | **SecLLMHolmes**         | ~228 scenarios | C/C++, Python  | Handcrafted bad/good pairs, 8 CWE classes (MIT)                                             |
 | **Juliet C/C++ 1.3.1**   | 64K cases      | C, C++         | NIST synthetic `bad()`/`good()` function pairs, ~180 CWEs                                   |
-| **DiverseVul**           | 349K functions | C, C++         | 18,945 CVE-backed vulnerable + 330,492 non-vulnerable (CWE-Unknown rows dropped by default — see playbook) |
 | **OWASP BenchmarkJava**  | ~2,740 cases   | Java           | `expectedresults-1.2.csv` (TP/FP per case, 11 CWE categories) — GPL-2.0                     |
 | **OWASP BenchmarkPython**| ~1,230 cases   | Python         | `expectedresults-0.1.csv` — GPL-3.0                                                         |
-| **RealVuln Benchmark**   | 796 findings   | Python         | Real CVE TPs + curated FP traps across 26 web-framework repos (Flask/Django/FastAPI/aiohttp/Tornado) — MIT |
+| **RealVuln Benchmark**   | 796 findings   | Python         | Real CVE TPs + curated FP traps across 26 web-framework repos — MIT                         |
+| **security-rules**       | 14 pairs       | Go/PHP/JS/Py   | In-repo `vuln`/`clean` fixtures for this project's custom rules — no download                |
 
-OWASP suites are cloned at runtime under `benchmarks/datasets/` rather than vendored; project code stays MIT and the GPL applies only to the cloned corpora. See [RESEARCH.md § Future Work](RESEARCH.md#planned-future-work) for the SastBench → RealVuln substitution rationale.
+**Track 2 — detection** (whole-function vuln labels; recall-only, *not* in the headline/model-matrix):
+
+| Dataset                  | Size           | Language       | Ground Truth                                                                                |
+| ------------------------ | -------------- | -------------- | ------------------------------------------------------------------------------------------- |
+| **DiverseVul** †         | 349K functions | C, C++         | CVE-backed function labels (~60% label accuracy — see RESEARCH.md §6.2)                      |
+
+† DiverseVul/CVEfixes are function-level detection sets: no real SAST alert, `target=0`≠SAST-FP, and labels are noisy. They measure recall/TP-preservation, **not** FP-reduction. The report marks them with `†` and excludes them from the model matrix.
+
+OWASP/OpenVuln/RealVuln suites are cloned at runtime under `benchmarks/datasets/` rather than vendored; project code stays MIT and any GPL applies only to the cloned corpora. See [RESEARCH.md § 6](RESEARCH.md#6-dataset-selection-guide--what-to-benchmark-on-and-why) for the full selection rationale and the SastBench → RealVuln substitution.
 
 ---
 
@@ -95,7 +107,7 @@ python benchmarks/scripts/setup_datasets.py --dataset all      # everything (~3 
 ```bash
 python benchmarks/scripts/run_benchmark.py \
     --dataset secllmholmes --approach all \
-    --model gpt-4o-mini --limit 50
+    --model gpt-4.1 --limit 50
 ```
 
 ### 5. Generate the report
@@ -110,7 +122,7 @@ python benchmarks/scripts/generate_report.py \
 
 ```bash
 python benchmarks/scripts/run_benchmark.py \
-    --dataset all --approach all --model gpt-4o
+    --dataset all --approach all --model gpt-5
 ```
 
 ### 7. Iteration sweep (measure multi-turn contribution)
@@ -118,7 +130,7 @@ python benchmarks/scripts/run_benchmark.py \
 ```bash
 python benchmarks/scripts/run_benchmark.py \
     --dataset secllmholmes --approach vulnhunterx \
-    --model gpt-4o-mini --iteration-sweep
+    --model gpt-4.1 --iteration-sweep
 # Runs at max_iterations = 1, 2, 3.
 ```
 
@@ -127,12 +139,12 @@ python benchmarks/scripts/run_benchmark.py \
 ```bash
 # Start with an explicit named directory:
 python benchmarks/scripts/run_benchmark.py \
-    --dataset all --approach all --model gpt-4o \
+    --dataset all --approach all --model gpt-5 \
     --run-dir benchmarks/results/my_run
 
 # Resume after an interruption:
 python benchmarks/scripts/run_benchmark.py \
-    --dataset all --approach all --model gpt-4o \
+    --dataset all --approach all --model gpt-5 \
     --run-dir benchmarks/results/my_run --resume
 ```
 
@@ -184,6 +196,46 @@ A single `OLLAMA_API_KEY=...` still works unchanged — the pool only activates 
 
 ---
 
+## Model Comparison Matrix (Ollama / GPT / DeepSeek)
+
+`run_benchmark.py` evaluates one model per run. To compare models head-to-head on
+the **same** dataset/approach, use the matrix runner — it launches one
+`run_benchmark.py` subprocess per model (each with an isolated credential env, so
+DeepSeek's `OPENAI_BASE_URL` doesn't bleed into a plain-OpenAI run) and writes a
+`matrix.json`. Then `compare_models.py` aggregates them into one `COMPARISON.md`.
+
+The matrix is defined in [config/models.yaml](config/models.yaml) — edit it to add
+models, pin a `pricing` file, or point at a per-model `.env`. Default tiers:
+`gpt-4.1` / `gpt-5` (GPT), `deepseek-chat` / `deepseek-reasoner` (DeepSeek),
+`ollama/qwen3-coder:480b-cloud` (bulk).
+
+```bash
+# Dry-run the whole matrix (mock LLM, no API cost)
+python benchmarks/scripts/run_model_matrix.py \
+    --dataset security-rules --approach all --dry-run
+
+# Real comparison on a fixed subset across three models
+python benchmarks/scripts/run_model_matrix.py \
+    --models gpt-4.1,deepseek-chat,ollama-qwen3-coder \
+    --dataset openvuln --approach vulnhunterx --limit 50 \
+    --run-dir benchmarks/results/matrix_2026q2
+
+# Aggregate into a side-by-side table (+ optional charts)
+python benchmarks/scripts/compare_models.py \
+    --run-dir benchmarks/results/matrix_2026q2 --charts
+```
+
+Pricing auto-resolves per model from the built-in `DEFAULT_PRICING` (covers
+`gpt-*`, `gpt-5`, `deepseek-*`, `qwen*`, `claude*`); local/Ollama models impute to
+$0. Pass `--pricing <file>` or set `pricing:` in `models.yaml` to override.
+Forward dataset-specific flags after `--`, e.g. `… -- --juliet-per-cwe 20`.
+
+> Run the matrix on **Track-1** datasets (OpenVuln, OWASP, RealVuln, SecLLMHolmes,
+> security-rules). Track-2 detection sets (DiverseVul) are excluded from the
+> comparison — their numbers reflect the wrong task (see RESEARCH.md §6).
+
+---
+
 ## Per-Dataset Playbooks
 
 ### Juliet C/C++
@@ -194,12 +246,12 @@ Synthetic, balanced TP/FP pairs per CWE. `--juliet-per-cwe` controls scale.
 # Small sanity check — ~40 entries
 python benchmarks/scripts/run_benchmark.py \
     --dataset juliet --approach vulnhunterx \
-    --juliet-per-cwe 5 --model gpt-4o-mini --dry-run
+    --juliet-per-cwe 5 --model gpt-4.1 --dry-run
 
 # Standard run — 8 BENCHMARK_CWES × 20 entries, balanced TP/FP
 python benchmarks/scripts/run_benchmark.py \
     --dataset juliet --approach all \
-    --juliet-per-cwe 20 --model gpt-4o-mini
+    --juliet-per-cwe 20 --model gpt-4.1
 
 # Full Juliet — local model strongly recommended
 python benchmarks/scripts/run_benchmark.py \
@@ -210,7 +262,7 @@ python benchmarks/scripts/run_benchmark.py \
 # Multi-turn iteration sweep
 python benchmarks/scripts/run_benchmark.py \
     --dataset juliet --approach vulnhunterx \
-    --juliet-per-cwe 10 --model gpt-4o-mini --iteration-sweep
+    --juliet-per-cwe 10 --model gpt-4.1 --iteration-sweep
 ```
 
 ### DiverseVul
@@ -230,7 +282,7 @@ python benchmarks/scripts/run_benchmark.py \
 # Medium run, all CWEs
 python benchmarks/scripts/run_benchmark.py \
     --dataset diversevul --approach vulnhunterx \
-    --limit 5000 --model gpt-4o-mini
+    --limit 5000 --model gpt-4.1
 
 # Full dataset — local model only
 python benchmarks/scripts/run_benchmark.py \
@@ -262,12 +314,12 @@ python benchmarks/scripts/setup_datasets.py --dataset owasp-python
 
 # Java only
 python benchmarks/scripts/run_benchmark.py \
-    --dataset owasp-java --approach all --model gpt-4o-mini \
+    --dataset owasp-java --approach all --model gpt-4.1 \
     --run-dir benchmarks/results/owasp_java
 
 # Java + Python combined (--dataset owasp runs both suites sequentially)
 python benchmarks/scripts/run_benchmark.py \
-    --dataset owasp --approach vulnhunterx --model gpt-4o-mini
+    --dataset owasp --approach vulnhunterx --model gpt-4.1
 ```
 
 Use `--dataset owasp-java` or `--dataset owasp-python` to run one suite individually. `--dataset owasp` runs both.
@@ -286,7 +338,7 @@ python benchmarks/scripts/setup_datasets.py --dataset realvuln
 
 # Real run with a small model
 python benchmarks/scripts/run_benchmark.py \
-    --dataset realvuln --approach all --model gpt-4o-mini \
+    --dataset realvuln --approach all --model gpt-4.1 \
     --run-dir benchmarks/results/realvuln
 ```
 
@@ -327,11 +379,11 @@ or pass `repos_cache` programmatically when calling
 ```
 --dataset           secllmholmes | juliet | diversevul |
                     owasp-java | owasp-python | owasp |
-                    realvuln |
+                    realvuln | openvuln | security-rules |
                     all  (default: secllmholmes)
                     `owasp` runs both OWASP Java + Python; `all` runs every dataset.
 --approach          One or more of: raw-sast vulnhunterx ablation all  (default: all)
---model             LLM model name  (default: LLM_MODEL from .env, fallback gpt-4o)
+--model             LLM model name  (default: LLM_MODEL from .env, fallback gpt-4.1)
 --provider          openai | anthropic | ollama  (default: LLM_PROVIDER from .env)
 --limit N           Max entries per dataset, 0=all  (default: 0)
 --lang LANG [...]   Filter fixture entries by language: c cpp python javascript php java go
@@ -359,8 +411,9 @@ or pass `repos_cache` programmatically when calling
 
 ```
 --dataset  secllmholmes | juliet | diversevul |
-           owasp-java | owasp-python | realvuln |
+           owasp-java | owasp-python | realvuln | openvuln |
            all  (default: all)
+           (security-rules is in-repo — no download needed)
 --list     List available datasets and exit
 ```
 
@@ -452,12 +505,12 @@ Every run creates a new timestamped directory and does **not** auto-resume. Pair
 ```bash
 # Start with a stable directory name
 python benchmarks/scripts/run_benchmark.py \
-    --dataset all --approach all --model gpt-4o \
+    --dataset all --approach all --model gpt-5 \
     --run-dir benchmarks/results/my_run
 
 # Resume after Ctrl+C or system kill
 python benchmarks/scripts/run_benchmark.py \
-    --dataset all --approach all --model gpt-4o \
+    --dataset all --approach all --model gpt-5 \
     --run-dir benchmarks/results/my_run --resume
 
 # Inspect status mid-run

--- a/benchmarks/RESEARCH.md
+++ b/benchmarks/RESEARCH.md
@@ -281,11 +281,15 @@ The standard `vulnhunterx` run adds multi-turn context expansion on top — whic
 | ------------------------------------ | ------------------------------------------- | ----------- |
 | CPG-guided slicing (Phase 2)         | LLMxCPG: 68–91% code reduction              | **Planned** — needs CodeQL data-flow |
 | Self-consistency voting (CISC)       | 46% fewer samples for same accuracy         | **Optional** via `force_decision_samples` |
-| DiverseVul per-CWE sampling          | Same strategy as Juliet (balanced TP/FP)    | **Planned** |
+| Model matrix (Ollama/GPT/DeepSeek)   | Apples-to-apples cross-model comparison (Track 1) | **In progress** — see § 6.1 |
+| OpenVuln/ZeroFalse adapter           | Real CodeQL alerts + human TP/FP (best Track-1 fit) | **In progress** — see § 6.3 |
+| `security-rules` adapter             | Finding-shaped Go/PHP/JS coverage for this repo's rules | **In progress** — see § 6.4 |
+| DiverseVul → Track-2 (recall-only)   | ≈60% label accuracy; not FP-reduction       | **In progress** — see § 6.2 |
 | Confidence-calibration charts        | Validate High/Medium/Low confidence signals | **Planned** |
 | Youden Index + MCC scoring           | Match OWASP scorecard + SastBench paper     | **Planned** |
-| PrimeVul adapter                     | Cleaner C/C++ labels than DiverseVul        | **Planned** |
-| SastBench REST `/analyze` harness    | Submit to SastBench leaderboard             | **Planned** — see below |
+| PrimeVul adapter                     | Cleaner C/C++ Track-2 labels than DiverseVul | **Planned** — see § 6.2 |
+| SecBench.js / SARD-PHP / gosec       | Per-language Track-1 supplements            | **Planned** — see § 6.4 |
+| SastBench REST `/analyze` harness    | Submit to SastBench leaderboard             | **Planned** — data gated, see § 6.5 |
 
 ### Web-language coverage via OWASP Benchmark
 
@@ -308,6 +312,118 @@ Snippet extraction is best-effort: the adapter reads function lines from a per-r
 
 ---
 
+## 6. Dataset Selection Guide — what to benchmark on, and why
+
+This section records a web-verified (May 2026) review of which datasets fit
+VulnHunterX's actual task, and **why function-level CVE datasets (DiverseVul,
+CVEfixes) produced poor, misleading benchmark numbers**. Every dataset below was
+verified against its canonical repo/paper; citations are in § References.
+
+### 6.1 The task framing — two tracks, kept separate
+
+VulnHunterX is a **finding-level SAST false-positive reducer**: given a static
+analysis *alert* (rule_id + file + sink line + dataflow + guided questions), it
+decides True Positive vs False Positive. It is **not** a function-level
+vulnerability *detector*. These are different tasks and demand different datasets.
+The benchmark therefore reports two tracks that are **never folded into one
+headline P/R/F1**:
+
+| Track | Question answered | Datasets |
+| ----- | ----------------- | -------- |
+| **Track 1 — FP-reduction (primary)** | Given a real SAST alert, is it TP or FP? | OpenVuln/ZeroFalse, OWASP Java/Python, RealVuln, SecLLMHolmes, Juliet, `security-rules` |
+| **Track 2 — detection (secondary, caveated)** | Is this whole function vulnerable? | DiverseVul (recall-only), PrimeVul (future) |
+
+The cross-model comparison (Ollama / GPT / DeepSeek) is computed on **Track 1
+only**, so model rankings reflect the deployed task rather than detection noise.
+
+### 6.2 Why DiverseVul & CVEfixes benchmarked badly — **[Diagnosed]**
+
+Observed in `benchmarks/results/`: on DiverseVul, `vulnhunterx` showed **recall
+0.6 / TP-preservation 0.6** (dropping 40% of real vulns) and a per-CWE bucket at
+**precision 0.09** (near-random). Root causes are structural, not tuning:
+
+1. **Task mismatch.** The DiverseVul adapter emits a whole function with
+   `start_line=1`, **no sink, no dataflow**, and a `rule_id` *synthesized from the
+   CWE*. The verifier — built around a specific alert location — reasons blind.
+   This is the function-level detection task that SecLLMHolmes showed frontier
+   LLMs cap at ~40% accuracy on.
+2. **Label-semantics mismatch.** `target=0` (non-vulnerable function) is mapped to
+   `LABEL_FP`, but a non-vulnerable function is **not** a SAST false positive —
+   SAST never fires on most of them. Scoring on them measures classification, not
+   FP-reduction.
+3. **No real SAST stage.** The `raw-sast` baseline marks every entry TP (it echoes
+   the label; it does not run CodeQL/Semgrep), so `fp_reduction_rate` is
+   structurally unmeasurable on these datasets.
+4. **Label noise (verified).** DiverseVul's measured label accuracy is **≈60%**
+   (PrimeVul's independent manual analysis, matching DiverseVul's own noise
+   analysis); Croft et al. (ICSE 2023) found **20–71% of labels inaccurate** and
+   **17–99% duplicated** across real-world vuln datasets. CVEfixes is worse: labels
+   are fix-commit-derived at file/method level (`file_change.code_before/code_after`,
+   link table `fixes`, CWE in `cwe_classification`), so the fix is often in a
+   *different* function than the flagged one (tangled-commit noise), and it ships
+   **no negatives at all**.
+
+**Decision:** DiverseVul → Track-2, **recall / TP-preservation only**, excluded
+from the headline and the model matrix. **CVEfixes is dropped** (strictly worse for
+this tool). The *correct* (heavy) way to use function-level data for FP-reduction
+is to run real CodeQL/Semgrep over each function, keep only functions where a tool
+actually fires, then score the verifier against the function label — tracked as
+future work. **PrimeVul** ([arXiv:2403.18624](https://arxiv.org/abs/2403.18624),
+86–92% label accuracy, C/C++ only) is the cleaner Track-2 successor — but note a
+SOTA 7B model drops from 68% F1 (BigVul) to 3% F1 (PrimeVul); low absolute scores
+on PrimeVul are the *honest* signal, not a regression.
+
+### 6.3 Verified finding-shaped (Track-1) inventory
+
+| Dataset | Lang | Shape | Size | License | Status |
+| ------- | ---- | ----- | ---- | ------- | ------ |
+| **OpenVuln / ZeroFalse** | Java | **real CodeQL SARIF alerts + human TP/FP** | 58 (23 TP / 35 FP) | MIT | the exact shape of our pipeline — **highest-fidelity real set found** |
+| **OWASP Java/Python** | Java, Python | test-case TP/FP CSV; you run the tool | ~2,740 / ~1,230 | GPL-2.0 / 3.0 | wired |
+| **RealVuln** | Python web | per-finding TP + curated FP traps; ships Semgrep/Snyk/Sonar results | 796 | MIT | wired |
+| **SecLLMHolmes** | C/C++, Python | hand-crafted bad/good pairs | ~228 | MIT | wired |
+| **Juliet** | C, C++ | synthetic `bad()`/`good()` | 64K | CC0 | wired |
+| **`security-rules`** | Go, PHP, JS, Python | in-repo `vuln`/`clean` pairs per custom rule | 14 pairs | (repo) | planned — validates this repo's own new rules |
+
+### 6.4 Go / PHP / JavaScript coverage — the gap and the verified fix
+
+VulnHunterX now ships custom rules for Go/PHP/JS, but **no mainstream dataset
+covers them finding-shaped** — verified non-existent: OWASP Benchmark for
+Go/PHP/JS, and NIST SARD Go/JS/TS suites. The verified, recognized fix is to use
+**SAST rule test fixtures as ground truth** (Semgrep `// ruleid:` / `// ok:`
+annotations with `semgrep --test`; CodeQL `.expected` files with `codeql test
+run`). The in-repo [tests/fixtures/security-rules/](../tests/fixtures/security-rules/)
+already follows this pattern, so the `security-rules` adapter is the first instance.
+Per-language verified supplements (roadmap):
+
+- **JavaScript** — [SecBench.js](https://github.com/cristianstaicu/SecBench.js)
+  (ICSE 2023): 600 real server-side JS vulns with **file+line `sinkLocation`** +
+  fix commit (prototype pollution, path traversal, command injection, ReDoS, code
+  injection) — maps directly to a SARIF region.
+- **PHP** — NIST SARD PHP suites
+  ([103](https://samate.nist.gov/SARD/test-suites/103) /
+  [114](https://samate.nist.gov/SARD/test-suites/114)): tens of thousands of
+  CWE-labeled synthetic XSS/SQLi cases, public domain — **same shape as Juliet**, so
+  the adapter is largely a JulietAdapter clone.
+- **Go** — [gosec](https://github.com/securego/gosec) `testutils`/`testdata`
+  (Apache-2.0): finding-shaped rule samples with expected-issue counts, category-
+  aligned with our Go rules; small N per rule.
+- Multi-language real CVE volume (Track-2 only, function-level/noisy): CVEfixes (JS
+  46,802 / PHP 4,758 / Go 1,880) and [CrossVul](https://zenodo.org/records/4734050)
+  (40+ langs) — usable for recall studies, **not** for precision/FP-reduction.
+
+### 6.5 Datasets evaluated and rejected
+
+- **SastBench** ([arXiv:2601.02941](https://arxiv.org/abs/2601.02941)) — ideal shape
+  (real CVE TPs + Semgrep FPs, 38 langs) but the **public data is gated/early-access**;
+  RealVuln remains the substitute until it ships.
+- **D2A** (IBM, Apache-2.0) — large Infer alert-level set, but **archived (Jul 2024)**,
+  C/C++/Infer-only, and Croft et al. rate >⅔ of its labels inaccurate
+  (consistency 0.531). Only worth wiring if Infer support is added.
+- **CASTLE** ([arXiv:2503.09433](https://arxiv.org/abs/2503.09433)) — clean balanced
+  micro-benchmark but **C-only**; does not help the Go/PHP/JS gap.
+
+---
+
 ## References
 
 - [LLM4FPM](https://arxiv.org/abs/2411.03079) — Su F. et al. (2024). Juliet C/C++ multi-turn LLM FP mitigation.
@@ -324,3 +440,12 @@ Snippet extraction is best-effort: the adapter reads function lines from a per-r
 - [SastBench](https://arxiv.org/abs/2601.02941) — agentic SAST triage benchmark; public repo URL not located at integration time.
 - [RealVuln Benchmark](https://github.com/kolega-ai/Real-Vuln-Benchmark) — real CVE TPs + FP traps for Python web frameworks (MIT); used as the SastBench substitute.
 - [Juliet C/C++ 1.3.1](https://samate.nist.gov/SARD/test-suites/116) — NIST SARD test suite.
+- [ZeroFalse / OpenVuln](https://github.com/mhsniranmanesh/ZeroFalse) — 58 real CodeQL SARIF alerts with human TP/FP labels across 7 Java projects (MIT).
+- [PrimeVul](https://github.com/DLVulDet/PrimeVul) — Ding Y., et al. (2024). Re-labeled C/C++ vuln dataset (86–92% label accuracy); ICSE 2025. [arXiv:2403.18624](https://arxiv.org/abs/2403.18624).
+- [Croft et al. Data Quality](https://arxiv.org/abs/2301.05456) — 20–71% of vuln-dataset labels inaccurate, 17–99% duplicated. ICSE 2023.
+- [SecBench.js](https://github.com/cristianstaicu/SecBench.js) — 600 real server-side JS vulns with file+line sink locations. ICSE 2023.
+- [NIST SARD PHP suites](https://samate.nist.gov/SARD/test-suites) — CWE-labeled synthetic PHP cases ([103](https://samate.nist.gov/SARD/test-suites/103), [114](https://samate.nist.gov/SARD/test-suites/114)); public domain. SARD covers C/C++/Java/PHP/C# only.
+- [gosec](https://github.com/securego/gosec) — Go SAST with finding-shaped rule testdata (Apache-2.0).
+- [CVEfixes](https://github.com/secureIT-project/CVEfixes) — multi-language CVE-fix SQLite DB; function-level/fix-commit labels (Track-2 only). [arXiv:2107.08760](https://arxiv.org/abs/2107.08760).
+- [CrossVul](https://zenodo.org/records/4734050) — 40+ language file-level vuln/patch pairs. ESEC/FSE 2021.
+- Semgrep [rule testing](https://semgrep.dev/docs/writing-rules/testing-rules) & CodeQL [query testing](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) — `ruleid:`/`ok:` and `.expected` fixtures as ground truth.

--- a/benchmarks/adapters/ground_truth.py
+++ b/benchmarks/adapters/ground_truth.py
@@ -9,7 +9,6 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
-
 # Valid label values
 LABEL_TP = "TP"       # Code IS vulnerable (ground truth)
 LABEL_FP = "FP"       # Code is SAFE but SAST incorrectly flags it

--- a/benchmarks/adapters/juliet_adapter.py
+++ b/benchmarks/adapters/juliet_adapter.py
@@ -25,7 +25,7 @@ import logging
 import re
 from pathlib import Path
 
-from benchmarks.adapters.cwe_rule_map import CWE_TO_RULES, primary_rule, primary_rule_for_lang
+from benchmarks.adapters.cwe_rule_map import primary_rule_for_lang
 from benchmarks.adapters.ground_truth import LABEL_FP, LABEL_TP, GroundTruthEntry
 from benchmarks.adapters.registry import (
     DatasetAdapter,

--- a/benchmarks/adapters/openvuln_adapter.py
+++ b/benchmarks/adapters/openvuln_adapter.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 VinSOC Cyber
+
+"""Adapter for the OpenVuln dataset (from the ZeroFalse project).
+
+Source: https://github.com/mhsniranmanesh/ZeroFalse  (MIT)
+Paper:  https://arxiv.org/abs/2510.02534
+
+OpenVuln is the highest-fidelity *real* SAST-FP-reduction set found: 58 real
+CodeQL SARIF alerts across 7 Java projects, each labeled TP/FP by comparing the
+vulnerable vs. patched version. This is exactly the shape VulnHunterX consumes
+(a CodeQL alert + a ground-truth verdict), so it is a Track-1 (FP-reduction)
+dataset — unlike function-level detection sets (DiverseVul/CVEfixes).
+
+Layout (after `git clone`):
+    ZeroFalse/OpenVuln/
+    ├── ground_truth.csv     # project_slug, alert_number, cve_id, filename, is_vulnerable
+    ├── Projects_info.csv     # project_slug, cve_id, cwe_id, cwe_name, ...
+    ├── sarif-files/<project_slug>.sarif
+    └── code-context/{baseline,optimized,method-finder}/.../<filename>
+
+Labels:
+    is_vulnerable == True  → LABEL_TP   (real vulnerability the CodeQL alert caught)
+    is_vulnerable == False → LABEL_FP   (CodeQL alert that is a false positive)
+
+Snippet extraction is best-effort: the per-alert code-context file named in
+``ground_truth.csv`` is searched under ``code-context/`` and read if found;
+otherwise the entry is tagged ``metadata.snippet_kind = "missing"`` (still
+scores for raw-sast comparison).
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import re
+from pathlib import Path
+from typing import ClassVar
+
+from benchmarks.adapters.ground_truth import LABEL_FP, LABEL_TP, GroundTruthEntry
+from benchmarks.adapters.registry import DatasetAdapter, register_adapter
+
+logger = logging.getLogger(__name__)
+
+_MAX_SNIPPET_CHARS = 8000
+# vulnerability_java_path-injection_9.txt -> lang=java, slug=path-injection
+_FILENAME_RE = re.compile(r"_(?P<lang>[a-z]+)_(?P<slug>[a-z0-9-]+)_(?P<num>\d+)\.txt$")
+
+
+def _normalize_cwe(raw: str) -> str:
+    """``CWE-022`` -> ``CWE-22`` (strip zero-padding so the CWE map matches)."""
+    raw = (raw or "").strip().upper()
+    m = re.match(r"CWE-0*(\d+)$", raw)
+    return f"CWE-{m.group(1)}" if m else raw
+
+
+def _rule_id_from_filename(filename: str) -> tuple[str, str]:
+    """Return (rule_id, lang) derived from the code-context filename.
+
+    ``vulnerability_java_path-injection_9.txt`` -> ("java/path-injection", "java").
+    Falls back to ("", "java") when the pattern doesn't match.
+    """
+    m = _FILENAME_RE.search(filename)
+    if not m:
+        return "", "java"
+    lang = m.group("lang")
+    return f"{lang}/{m.group('slug')}", lang
+
+
+@register_adapter
+class OpenVulnAdapter(DatasetAdapter):
+    """Load OpenVuln (ZeroFalse) CodeQL alerts as TP/FP GroundTruthEntry objects."""
+
+    name = "openvuln"
+    langs: ClassVar[tuple[str, ...]] = ("java",)
+    family = "cve"
+    option_schema: ClassVar[dict] = {}
+    install_url = "https://github.com/mhsniranmanesh/ZeroFalse.git"
+    expected_files = ("OpenVuln/ground_truth.csv",)
+
+    def __init__(self, dataset_path: Path) -> None:
+        p = Path(dataset_path)
+        # Accept either a ZeroFalse clone root or the OpenVuln dir directly.
+        self.base = p / "OpenVuln" if (p / "OpenVuln").is_dir() else p
+
+    def _cwe_by_project(self) -> dict[str, str]:
+        info = self.base / "Projects_info.csv"
+        if not info.is_file():
+            return {}
+        out: dict[str, str] = {}
+        with info.open(encoding="utf-8") as fh:
+            for row in csv.DictReader(fh):
+                slug = (row.get("project_slug") or "").strip()
+                if slug:
+                    out[slug] = _normalize_cwe(row.get("cwe_id", ""))
+        return out
+
+    def _find_snippet(self, filename: str) -> str:
+        """Best-effort: locate the named code-context file anywhere under
+        code-context/ and return its contents (capped)."""
+        ctx = self.base / "code-context"
+        if not ctx.is_dir() or not filename:
+            return ""
+        matches = list(ctx.rglob(filename))
+        if not matches:
+            return ""
+        try:
+            return matches[0].read_text(encoding="utf-8", errors="replace")[:_MAX_SNIPPET_CHARS]
+        except OSError:
+            return ""
+
+    def load(self, limit: int = 0) -> list[GroundTruthEntry]:
+        gt = self.base / "ground_truth.csv"
+        if not gt.is_file():
+            raise FileNotFoundError(
+                f"OpenVuln ground_truth.csv not found under {self.base}. "
+                "Clone https://github.com/mhsniranmanesh/ZeroFalse."
+            )
+        cwe_by_project = self._cwe_by_project()
+
+        entries: list[GroundTruthEntry] = []
+        missing_snippets = 0
+        with gt.open(encoding="utf-8") as fh:
+            for row in csv.DictReader(fh):
+                slug = (row.get("project_slug") or "").strip()
+                alert = (row.get("alert_number") or "").strip()
+                filename = (row.get("filename") or "").strip()
+                is_vuln = (row.get("is_vulnerable") or "").strip().lower() == "true"
+                if not slug or not filename:
+                    continue
+
+                rule_id, lang = _rule_id_from_filename(filename)
+                cwe_id = cwe_by_project.get(slug, "")
+                snippet = self._find_snippet(filename)
+                snippet_kind = "code-context" if snippet else "missing"
+                if not snippet:
+                    missing_snippets += 1
+
+                entries.append(
+                    GroundTruthEntry(
+                        id=f"openvuln-{slug}-{alert}",
+                        source_dataset="openvuln",
+                        cwe_id=cwe_id,
+                        rule_id=rule_id,
+                        file_path=filename,
+                        function_name="",
+                        start_line=1,
+                        lang=lang,
+                        label=LABEL_TP if is_vuln else LABEL_FP,
+                        code_snippet=snippet,
+                        metadata={
+                            "project_slug": slug,
+                            "alert_number": alert,
+                            "cve_id": (row.get("cve_id") or "").strip(),
+                            "snippet_kind": snippet_kind,
+                        },
+                    )
+                )
+                if limit and len(entries) >= limit:
+                    break
+
+        logger.info(
+            "openvuln: loaded %d entries (%d TP, %d FP); %d missing snippets",
+            len(entries),
+            sum(1 for e in entries if e.label == LABEL_TP),
+            sum(1 for e in entries if e.label == LABEL_FP),
+            missing_snippets,
+        )
+        return entries

--- a/benchmarks/adapters/registry.py
+++ b/benchmarks/adapters/registry.py
@@ -209,6 +209,8 @@ def _ensure_loaded() -> None:
         "benchmarks.adapters.secllmholmes_adapter",
         "benchmarks.adapters.realvuln_adapter",
         "benchmarks.adapters.owasp_benchmark_adapter",
+        "benchmarks.adapters.security_rules_adapter",
+        "benchmarks.adapters.openvuln_adapter",
     ):
         try:
             __import__(modname)

--- a/benchmarks/adapters/security_rules_adapter.py
+++ b/benchmarks/adapters/security_rules_adapter.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 VinSOC Cyber
+
+"""Adapter for the in-repo custom-rule fixtures (Go / PHP / JS / Python).
+
+Source: ``tests/fixtures/security-rules/<lang>/<rule>/{vuln,clean}.<ext>``
+
+These are the project's own SAST rule test fixtures — one directory per custom
+rule, holding a vulnerable (``vuln.*``) and a safe (``clean.*``) variant. Using
+SAST rule test fixtures as ground truth is a recognized practice (Semgrep
+``ruleid:``/``ok:`` annotations, CodeQL ``.expected`` files). This is the
+finding-shaped, balanced TP/FP dataset for the Go/PHP/JS languages whose rules
+have no public benchmark — and it validates *this repo's* new rules directly.
+
+Labels:
+    vuln.<ext>  → LABEL_TP  (rule should fire)
+    clean.<ext> → LABEL_FP  (rule must NOT fire — a real false-positive trap)
+
+``rule_id`` is the actual Semgrep custom-rule id (``vulnhunterx.<lp>.<rule>``)
+when the rule is found in ``config/semgrep-custom/<lang>.yaml``, else the
+CodeQL-style ``<lang>/<rule>``. ``cwe_id`` is read from the Semgrep rule
+metadata so the verification engine's CWE-fallback question routing works.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import ClassVar
+
+import yaml
+
+from benchmarks.adapters.ground_truth import LABEL_FP, LABEL_TP, GroundTruthEntry
+from benchmarks.adapters.registry import (
+    DatasetAdapter,
+    OptionSpec,
+    _to_csv_list,
+    register_adapter,
+)
+
+logger = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FIXTURES_ROOT = _REPO_ROOT / "tests" / "fixtures" / "security-rules"
+_SEMGREP_CUSTOM = _REPO_ROOT / "config" / "semgrep-custom"
+_MAX_SNIPPET_CHARS = 8000
+
+# fixture-dir lang → (GroundTruthEntry lang, source-file ext, semgrep id prefix,
+# semgrep yaml stem).
+_LANG_SPEC: dict[str, tuple[str, str, str, str]] = {
+    "go": ("go", ".go", "go", "go"),
+    "php": ("php", ".php", "php", "php"),
+    "javascript": ("javascript", ".js", "js", "javascript"),
+    "python": ("python", ".py", "py", "python"),
+}
+
+
+def _load_semgrep_cwe_map(yaml_stem: str) -> dict[str, str]:
+    """Map ``<rule-name>`` → primary CWE from config/semgrep-custom/<stem>.yaml."""
+    path = _SEMGREP_CUSTOM / f"{yaml_stem}.yaml"
+    if not path.is_file():
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        logger.warning("Could not parse %s for CWE metadata", path)
+        return {}
+    out: dict[str, str] = {}
+    for rule in data.get("rules", []):
+        rule_id = str(rule.get("id", ""))
+        if not rule_id:
+            continue
+        rule_name = rule_id.rsplit(".", 1)[-1]  # vulnhunterx.go.x -> x
+        cwes = (rule.get("metadata") or {}).get("cwe") or []
+        if isinstance(cwes, str):
+            cwes = [cwes]
+        out[rule_name] = str(cwes[0]) if cwes else ""
+    return out
+
+
+@register_adapter
+class SecurityRulesAdapter(DatasetAdapter):
+    """Load the in-repo custom-rule vuln/clean fixtures as TP/FP pairs."""
+
+    name = "security-rules"
+    langs: ClassVar[tuple[str, ...]] = ("go", "php", "javascript", "python")
+    family = "custom"
+    option_schema: ClassVar[dict[str, OptionSpec]] = {
+        "langs": OptionSpec(
+            _to_csv_list,
+            default=None,
+            help="Comma-separated languages to include (e.g. go,php).",
+        ),
+    }
+    install_url = None  # in-repo; no download
+    expected_files = ("go", "php", "javascript", "python")
+
+    def __init__(self, dataset_path: Path) -> None:
+        # Prefer the given path if it holds the lang subdirs; else fall back to
+        # the canonical in-repo fixtures location.
+        p = Path(dataset_path)
+        self.root = p if (p / "go").is_dir() or (p / "php").is_dir() else _FIXTURES_ROOT
+
+    def load(
+        self,
+        limit: int = 0,
+        langs: list[str] | None = None,
+    ) -> list[GroundTruthEntry]:
+        wanted = set(langs) if langs else None
+        entries: list[GroundTruthEntry] = []
+        for lang_dir in sorted(self.root.iterdir() if self.root.is_dir() else []):
+            if not lang_dir.is_dir():
+                continue
+            spec = _LANG_SPEC.get(lang_dir.name)
+            if spec is None:
+                continue
+            gt_lang, ext, id_prefix, yaml_stem = spec
+            if wanted and gt_lang not in wanted and lang_dir.name not in wanted:
+                continue
+            cwe_map = _load_semgrep_cwe_map(yaml_stem)
+
+            for rule_dir in sorted(lang_dir.iterdir()):
+                if not rule_dir.is_dir():
+                    continue
+                rule_name = rule_dir.name
+                if rule_name in cwe_map:
+                    rule_id = f"vulnhunterx.{id_prefix}.{rule_name}"
+                    cwe_id = cwe_map[rule_name]
+                else:
+                    rule_id = f"{gt_lang}/{rule_name}"  # CodeQL @id style
+                    cwe_id = ""
+
+                for variant, label in (("vuln", LABEL_TP), ("clean", LABEL_FP)):
+                    matches = list(rule_dir.glob(f"{variant}{ext}")) or list(
+                        rule_dir.glob(f"{variant}.*")
+                    )
+                    if not matches:
+                        continue
+                    code_file = matches[0]
+                    try:
+                        snippet = code_file.read_text(encoding="utf-8", errors="replace")
+                    except OSError:
+                        logger.warning("Cannot read %s; skipping", code_file)
+                        continue
+                    entries.append(
+                        GroundTruthEntry(
+                            id=f"secrule-{gt_lang}-{rule_name}-{variant}",
+                            source_dataset="security-rules",
+                            cwe_id=cwe_id,
+                            rule_id=rule_id,
+                            file_path=str(code_file.relative_to(self.root)),
+                            function_name="",
+                            start_line=1,
+                            lang=gt_lang,
+                            label=label,
+                            code_snippet=snippet[:_MAX_SNIPPET_CHARS],
+                            metadata={
+                                "rule_name": rule_name,
+                                "variant": variant,
+                            },
+                        )
+                    )
+                    if limit and len(entries) >= limit:
+                        logger.info("security-rules: loaded %d entries (limit)", len(entries))
+                        return entries
+
+        logger.info(
+            "security-rules: loaded %d entries (%d TP, %d FP) from %s",
+            len(entries),
+            sum(1 for e in entries if e.label == LABEL_TP),
+            sum(1 for e in entries if e.label == LABEL_FP),
+            self.root,
+        )
+        return entries

--- a/benchmarks/approaches/ablation.py
+++ b/benchmarks/approaches/ablation.py
@@ -25,17 +25,12 @@ import time
 from pathlib import Path
 from typing import Any
 
-from vuln_hunter_x.core.config import Config
-from vuln_hunter_x.core.types import GuidedQuestions
-from vuln_hunter_x.questions.loader import QuestionsLoader
-from vuln_hunter_x.verification.engine import VerificationEngine
-
 from benchmarks.adapters.ground_truth import GroundTruthEntry
 from benchmarks.adapters.registry import OptionSpec
 from benchmarks.approaches.base import (
     BenchmarkResult,
-    _SnippetContextExtractor,
     _dry_run_result,
+    _SnippetContextExtractor,
     entry_to_finding,
     verdict_to_pred,
 )
@@ -44,6 +39,10 @@ from benchmarks.approaches.registry import (
     RegisteredApproach,
     register_approach,
 )
+from vuln_hunter_x.core.config import Config
+from vuln_hunter_x.core.types import GuidedQuestions
+from vuln_hunter_x.questions.loader import QuestionsLoader
+from vuln_hunter_x.verification.engine import VerificationEngine
 
 # Default prompts directory (all language-specific YAMLs)
 _PROMPTS_DIR = Path(__file__).resolve().parents[2] / "config" / "prompts"
@@ -78,7 +77,7 @@ class AblationApproach(RegisteredApproach):
     @classmethod
     def from_options(
         cls, llm: LLMConfig | None, options: dict[str, Any]
-    ) -> "AblationApproach":
+    ) -> AblationApproach:
         llm = llm or LLMConfig()
         return cls(
             provider=llm.provider,

--- a/benchmarks/approaches/raw_sast.py
+++ b/benchmarks/approaches/raw_sast.py
@@ -34,7 +34,7 @@ class RawSastApproach(RegisteredApproach):
     @classmethod
     def from_options(
         cls, llm: LLMConfig | None, options: dict[str, Any]
-    ) -> "RawSastApproach":
+    ) -> RawSastApproach:
         # No options or LLM context to apply.
         return cls()
 

--- a/benchmarks/approaches/vulnhunterx.py
+++ b/benchmarks/approaches/vulnhunterx.py
@@ -7,20 +7,14 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-
 from typing import Any
-
-from vuln_hunter_x.context.snippet_provider import SnippetContextProvider
-from vuln_hunter_x.core.config import Config
-from vuln_hunter_x.questions.loader import QuestionsLoader
-from vuln_hunter_x.verification.engine import VerificationEngine
 
 from benchmarks.adapters.ground_truth import GroundTruthEntry
 from benchmarks.adapters.registry import OptionSpec, _to_bool
 from benchmarks.approaches.base import (
     BenchmarkResult,
-    _SnippetContextExtractor,
     _dry_run_result,
+    _SnippetContextExtractor,
     entry_to_finding,
     verdict_to_pred,
 )
@@ -29,6 +23,10 @@ from benchmarks.approaches.registry import (
     RegisteredApproach,
     register_approach,
 )
+from vuln_hunter_x.context.snippet_provider import SnippetContextProvider
+from vuln_hunter_x.core.config import Config
+from vuln_hunter_x.questions.loader import QuestionsLoader
+from vuln_hunter_x.verification.engine import VerificationEngine
 
 # Default prompts directory containing all per-language *_questions.yaml files
 _PROMPTS_DIR = (
@@ -69,7 +67,7 @@ class VulnHunterXApproach(RegisteredApproach):
     @classmethod
     def from_options(
         cls, llm: LLMConfig | None, options: dict[str, Any]
-    ) -> "VulnHunterXApproach":
+    ) -> VulnHunterXApproach:
         llm = llm or LLMConfig()
         return cls(
             provider=llm.provider,

--- a/benchmarks/config/benchmark.yaml
+++ b/benchmarks/config/benchmark.yaml
@@ -14,11 +14,12 @@ datasets:
 # ── LLM settings ──────────────────────────────────────────────────────────────
 llm:
   provider: openai
-  model: gpt-4o           # default model; override with --model
+  model: gpt-4.1          # default model; override with --model
   # Alternatives:
-  #   model: claude-sonnet-4-6   # Anthropic (set ANTHROPIC_API_KEY)
-  #   model: gpt-4o-mini          # cheaper, faster
-  #   model: ollama/llama3.2      # local (set OLLAMA_API_BASE)
+  #   model: gpt-5                # frontier ceiling (more expensive)
+  #   model: deepseek-reasoner    # cost-effective frontier reasoning
+  #   model: claude-sonnet-4-6    # Anthropic (set ANTHROPIC_API_KEY)
+  #   model: ollama/qwen3-coder:480b-cloud  # bulk/scale (set OLLAMA_API_BASE/KEYS)
 
 # ── Verification settings ─────────────────────────────────────────────────────
 verification:

--- a/benchmarks/config/models.yaml
+++ b/benchmarks/config/models.yaml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 VinSOC Cyber
+#
+# Model matrix for cross-model benchmark comparison (Ollama / GPT / DeepSeek).
+# Read by benchmarks/scripts/run_model_matrix.py.
+#
+# Each entry runs the SAME dataset(s)/approach(es) as a separate
+# `run_benchmark.py` subprocess into its own results subdir, then
+# compare_models.py aggregates them into one COMPARISON.md.
+#
+# Fields per entry:
+#   id        unique label; names the results subdir and the COMPARISON row
+#   provider  openai | ollama | anthropic  (passed as --provider)
+#   model     model id passed as --model (LLMClient adds provider prefixes)
+#   tier      dev | bulk | headline  (documentation; not enforced)
+#   env       optional path (repo-root-relative) to a .env file whose vars are
+#             overlaid on the subprocess environment — gives each model a clean,
+#             isolated credential set (DeepSeek vs OpenAI vs Ollama don't collide)
+#   pricing   optional path to a JSON pricing schedule; omit to use the built-in
+#             DEFAULT_PRICING (covers gpt-*, gpt-5, deepseek-*, qwen*, claude*;
+#             ollama/* imputes to $0)
+#
+# Pricing note: GPT models are gpt-4.1 (cost-effective frontier) and gpt-5
+# (frontier ceiling). DeepSeek is the cheap frontier-reasoning tier. Ollama
+# (local or cloud pool) is the only viable option at full-Juliet/DiverseVul scale.
+
+models:
+  # ── Headline tier (publishable, fixed-seed Track-1 subset) ──
+  - id: gpt-4.1
+    provider: openai
+    model: gpt-4.1
+    tier: headline
+    env: .env.openai
+
+  - id: gpt-5
+    provider: openai
+    model: gpt-5
+    tier: headline
+    env: .env.openai
+
+  - id: deepseek-reasoner
+    provider: openai
+    model: deepseek-reasoner
+    tier: headline
+    env: .env.deepseek
+
+  # ── Bulk / scale tier ──
+  - id: deepseek-chat
+    provider: openai
+    model: deepseek-chat
+    tier: bulk
+    env: .env.deepseek
+
+  - id: ollama-qwen3-coder
+    provider: ollama
+    model: ollama/qwen3-coder:480b-cloud
+    tier: bulk
+    env: .env.ollama

--- a/benchmarks/datasets.yaml
+++ b/benchmarks/datasets.yaml
@@ -49,6 +49,21 @@ datasets:
     dirname: realvuln
     disk_mb: 30
 
+  openvuln:
+    description: "OpenVuln (ZeroFalse): 58 real CodeQL alerts with human TP/FP labels, 7 Java projects (MIT)"
+    type: git
+    url: "https://github.com/mhsniranmanesh/ZeroFalse"
+    dirname: openvuln
+    disk_mb: 60
+
+  # security-rules is in-repo (tests/fixtures/security-rules/) — no download.
+  # run_benchmark resolves its path directly; listed here for discoverability.
+  security-rules:
+    description: "In-repo custom-rule vuln/clean fixtures (Go/PHP/JS/Python) — finding-shaped, no download"
+    type: builtin
+    dirname: security-rules
+    disk_mb: 0
+
   diversevul:
     description: "DiverseVul: 349K C/C++ functions with real CVE-backed labels (150 CWEs)"
     type: gdrive

--- a/benchmarks/fixtures/openvuln_sample.json
+++ b/benchmarks/fixtures/openvuln_sample.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "openvuln-perwendel__spark_CVE-2016-9177_2.5.1-1",
+    "source_dataset": "openvuln",
+    "cwe_id": "CWE-22",
+    "rule_id": "java/path-injection",
+    "file_path": "vulnerability_java_path-injection_1.txt",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "java",
+    "label": "TP",
+    "code_snippet": "// CodeQL alert: path-injection — user-controlled path reaches file read\nString path = request.getPathInfo();\nFile f = new File(webRoot, path); // no canonicalization / traversal check\nreturn Files.readAllBytes(f.toPath());",
+    "metadata": {
+      "project_slug": "perwendel__spark_CVE-2016-9177_2.5.1",
+      "alert_number": "1",
+      "cve_id": "CVE-2016-9177",
+      "snippet_kind": "code-context"
+    }
+  },
+  {
+    "id": "openvuln-perwendel__spark_CVE-2016-9177_2.5.1-12",
+    "source_dataset": "openvuln",
+    "cwe_id": "CWE-22",
+    "rule_id": "java/path-injection",
+    "file_path": "vulnerability_java_path-injection_12.txt",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "java",
+    "label": "FP",
+    "code_snippet": "// CodeQL alert flagged this path, but the value is validated against an\n// allow-list before use — a false positive.\nString name = request.getParameter(\"page\");\nif (!ALLOWED_PAGES.contains(name)) { return notFound(); }\nreturn render(TEMPLATES.get(name));",
+    "metadata": {
+      "project_slug": "perwendel__spark_CVE-2016-9177_2.5.1",
+      "alert_number": "12",
+      "cve_id": "CVE-2016-9177",
+      "snippet_kind": "code-context"
+    }
+  },
+  {
+    "id": "openvuln-keycloak__keycloak_CVE-2022-4361_21.1.1-3",
+    "source_dataset": "openvuln",
+    "cwe_id": "CWE-79",
+    "rule_id": "java/xss",
+    "file_path": "vulnerability_java_xss_3.txt",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "java",
+    "label": "TP",
+    "code_snippet": "// CodeQL alert: reflected XSS — request param written to response unescaped\nString q = request.getParameter(\"q\");\nresponse.getWriter().write(\"<div>\" + q + \"</div>\");",
+    "metadata": {
+      "project_slug": "keycloak__keycloak_CVE-2022-4361_21.1.1",
+      "alert_number": "3",
+      "cve_id": "CVE-2022-4361",
+      "snippet_kind": "code-context"
+    }
+  }
+]

--- a/benchmarks/fixtures/security-rules_sample.json
+++ b/benchmarks/fixtures/security-rules_sample.json
@@ -1,0 +1,450 @@
+[
+  {
+    "id": "secrule-go-goroutine-leak-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-405",
+    "rule_id": "vulnhunterx.go.goroutine-leak",
+    "file_path": "go/goroutine-leak/vuln.go",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "go",
+    "label": "TP",
+    "code_snippet": "// CWE-405: goroutine writes to unbuffered channel without receiver guard\npackage main\n\nimport \"fmt\"\n\nfunc leaker() {\n\tch := make(chan int)\n\tgo func() {\n\t\tch <- 42\n\t\tfmt.Println(\"done\") // unreachable if no receiver\n\t}()\n\t// no receive \u2014 goroutine leaks\n}\n",
+    "metadata": {
+      "rule_name": "goroutine-leak",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-go-goroutine-leak-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-405",
+    "rule_id": "vulnhunterx.go.goroutine-leak",
+    "file_path": "go/goroutine-leak/clean.go",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "go",
+    "label": "FP",
+    "code_snippet": "// Buffered channel \u2014 goroutine completes without a receiver\npackage main\n\nimport \"fmt\"\n\nfunc bounded() {\n\tch := make(chan int, 1)\n\tgo func() {\n\t\tch <- 42\n\t\tfmt.Println(\"done\")\n\t}()\n\tv := <-ch\n\tfmt.Println(v)\n}\n",
+    "metadata": {
+      "rule_name": "goroutine-leak",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-go-panic-in-handler-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-248",
+    "rule_id": "vulnhunterx.go.panic-in-handler",
+    "file_path": "go/panic-in-handler/vuln.go",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "go",
+    "label": "TP",
+    "code_snippet": "// CWE-248: handler panics without defer recover\npackage main\n\nimport \"net/http\"\n\nfunc handler(w http.ResponseWriter, r *http.Request) {\n\tif r.URL.Path == \"/crash\" {\n\t\tpanic(\"boom\") // unrecovered\n\t}\n\tw.Write([]byte(\"ok\"))\n}\n",
+    "metadata": {
+      "rule_name": "panic-in-handler",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-go-panic-in-handler-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-248",
+    "rule_id": "vulnhunterx.go.panic-in-handler",
+    "file_path": "go/panic-in-handler/clean.go",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "go",
+    "label": "FP",
+    "code_snippet": "// Recovered handler \u2014 panic caught by deferred recover\npackage main\n\nimport (\n\t\"log\"\n\t\"net/http\"\n)\n\nfunc handler(w http.ResponseWriter, r *http.Request) {\n\tdefer func() {\n\t\tif rec := recover(); rec != nil {\n\t\t\tlog.Printf(\"recovered: %v\", rec)\n\t\t\thttp.Error(w, \"internal error\", 500)\n\t\t}\n\t}()\n\tif r.URL.Path == \"/crash\" {\n\t\tpanic(\"boom\")\n\t}\n\tw.Write([]byte(\"ok\"))\n}\n",
+    "metadata": {
+      "rule_name": "panic-in-handler",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-go-unsafe-pointer-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-704",
+    "rule_id": "vulnhunterx.go.unsafe-pointer",
+    "file_path": "go/unsafe-pointer/vuln.go",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "go",
+    "label": "TP",
+    "code_snippet": "// CWE-704: unsafe.Pointer cast for type punning between unrelated types\npackage main\n\nimport \"unsafe\"\n\nfunc punned(buf []byte) uint32 {\n\treturn *(*uint32)(unsafe.Pointer(&buf[0]))\n}\n",
+    "metadata": {
+      "rule_name": "unsafe-pointer",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-go-unsafe-pointer-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-704",
+    "rule_id": "vulnhunterx.go.unsafe-pointer",
+    "file_path": "go/unsafe-pointer/clean.go",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "go",
+    "label": "FP",
+    "code_snippet": "// encoding/binary \u2014 safe, portable\npackage main\n\nimport \"encoding/binary\"\n\nfunc parsed(buf []byte) uint32 {\n\treturn binary.LittleEndian.Uint32(buf)\n}\n",
+    "metadata": {
+      "rule_name": "unsafe-pointer",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-javascript-electron-node-integration-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-1188",
+    "rule_id": "vulnhunterx.js.electron-node-integration",
+    "file_path": "javascript/electron-node-integration/vuln.js",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "javascript",
+    "label": "TP",
+    "code_snippet": "// CWE-1188: Electron BrowserWindow with nodeIntegration enabled\nconst { BrowserWindow } = require(\"electron\");\n\nfunction createWindow() {\n  const win = new BrowserWindow({\n    width: 800,\n    height: 600,\n    webPreferences: {\n      nodeIntegration: true,\n      contextIsolation: false,\n    },\n  });\n  win.loadURL(\"https://example.com\");\n  return win;\n}\n",
+    "metadata": {
+      "rule_name": "electron-node-integration",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-javascript-electron-node-integration-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-1188",
+    "rule_id": "vulnhunterx.js.electron-node-integration",
+    "file_path": "javascript/electron-node-integration/clean.js",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "javascript",
+    "label": "FP",
+    "code_snippet": "// Safe Electron defaults \u2014 nodeIntegration off, contextIsolation on\nconst { BrowserWindow } = require(\"electron\");\n\nfunction createWindow() {\n  const win = new BrowserWindow({\n    width: 800,\n    height: 600,\n    webPreferences: {\n      nodeIntegration: false,\n      contextIsolation: true,\n      preload: \"./preload.js\",\n    },\n  });\n  win.loadURL(\"https://example.com\");\n  return win;\n}\n",
+    "metadata": {
+      "rule_name": "electron-node-integration",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-javascript-html-injection-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-79",
+    "rule_id": "vulnhunterx.js.html-injection",
+    "file_path": "javascript/html-injection/vuln.js",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "javascript",
+    "label": "TP",
+    "code_snippet": "// CWE-79: innerHTML written from req.body \u2014 XSS\nfunction render(el, req) {\n  el.innerHTML = req.body.message;\n}\n",
+    "metadata": {
+      "rule_name": "html-injection",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-javascript-html-injection-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-79",
+    "rule_id": "vulnhunterx.js.html-injection",
+    "file_path": "javascript/html-injection/clean.js",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "javascript",
+    "label": "FP",
+    "code_snippet": "// Sanitized via DOMPurify \u2014 safe\nimport DOMPurify from \"dompurify\";\nfunction render(el, req) {\n  el.innerHTML = DOMPurify.sanitize(req.body.message);\n}\n",
+    "metadata": {
+      "rule_name": "html-injection",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-javascript-prototype-pollution-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-1321",
+    "rule_id": "vulnhunterx.js.prototype-pollution",
+    "file_path": "javascript/prototype-pollution/vuln.js",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "javascript",
+    "label": "TP",
+    "code_snippet": "// CWE-1321: bracket-property write keyed by req.body directly\nfunction merge(target, req) {\n  target[req.body.key] = req.body.value;\n  return target;\n}\nmodule.exports = { merge };\n",
+    "metadata": {
+      "rule_name": "prototype-pollution",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-javascript-prototype-pollution-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-1321",
+    "rule_id": "vulnhunterx.js.prototype-pollution",
+    "file_path": "javascript/prototype-pollution/clean.js",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "javascript",
+    "label": "FP",
+    "code_snippet": "// Guarded write \u2014 checks key against an allowlist\nfunction merge(target, req) {\n  const key = req.body.key;\n  if (key === \"__proto__\" || key === \"constructor\" || key === \"prototype\") {\n    throw new Error(\"forbidden key\");\n  }\n  target[key] = req.body.value;\n  return target;\n}\nmodule.exports = { merge };\n",
+    "metadata": {
+      "rule_name": "prototype-pollution",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-php-extract-injection-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-1062",
+    "rule_id": "vulnhunterx.php.extract-injection",
+    "file_path": "php/extract-injection/vuln.php",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "php",
+    "label": "TP",
+    "code_snippet": "<?php\n// CWE-1062: extract() from $_GET \u2014 attacker controls all local vars\nextract($_GET);\necho \"Logged in as \" . $user;\n",
+    "metadata": {
+      "rule_name": "extract-injection",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-php-extract-injection-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-1062",
+    "rule_id": "vulnhunterx.php.extract-injection",
+    "file_path": "php/extract-injection/clean.php",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "php",
+    "label": "FP",
+    "code_snippet": "<?php\n// EXTR_SKIP prevents overwriting existing variables\n$is_admin = false;\nextract($_GET, EXTR_SKIP);\nif ($is_admin) {\n    echo \"Admin panel\";\n}\n",
+    "metadata": {
+      "rule_name": "extract-injection",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-php-file-inclusion-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-98",
+    "rule_id": "vulnhunterx.php.file-inclusion",
+    "file_path": "php/file-inclusion/vuln.php",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "php",
+    "label": "TP",
+    "code_snippet": "<?php\n// CWE-98: user-controlled include path \u2192 LFI/RFI\n$page = $_GET[\"page\"];\ninclude($page);\n",
+    "metadata": {
+      "rule_name": "file-inclusion",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-php-file-inclusion-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-98",
+    "rule_id": "vulnhunterx.php.file-inclusion",
+    "file_path": "php/file-inclusion/clean.php",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "php",
+    "label": "FP",
+    "code_snippet": "<?php\n// Allowlist dispatch \u2014 safe\n$allowed = [\"home\" => \"home.php\", \"about\" => \"about.php\"];\n$page = $_GET[\"page\"] ?? \"home\";\nif (isset($allowed[$page])) {\n    include($allowed[$page]);\n}\n",
+    "metadata": {
+      "rule_name": "file-inclusion",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-php-type-juggling-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-1025",
+    "rule_id": "vulnhunterx.php.type-juggling",
+    "file_path": "php/type-juggling/vuln.php",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "php",
+    "label": "TP",
+    "code_snippet": "<?php\n// CWE-1025: loose comparison vs user input \u2014 type juggling bypass\n$expected_token = \"abc123\";\nif ($expected_token == $_POST[\"token\"]) {\n    echo \"Authenticated\";\n}\n",
+    "metadata": {
+      "rule_name": "type-juggling",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-php-type-juggling-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-1025",
+    "rule_id": "vulnhunterx.php.type-juggling",
+    "file_path": "php/type-juggling/clean.php",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "php",
+    "label": "FP",
+    "code_snippet": "<?php\n// Strict comparison \u2014 safe from type juggling\n$expected_token = \"abc123\";\nif ($expected_token === $_POST[\"token\"]) {\n    echo \"Authenticated\";\n}\n",
+    "metadata": {
+      "rule_name": "type-juggling",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-php-variable-variables-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-621",
+    "rule_id": "vulnhunterx.php.variable-variables",
+    "file_path": "php/variable-variables/vuln.php",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "php",
+    "label": "TP",
+    "code_snippet": "<?php\n// CWE-621: variable-variable assignment from user input\n$name = $_GET[\"name\"];\n$$name = $_GET[\"value\"];\n",
+    "metadata": {
+      "rule_name": "variable-variables",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-php-variable-variables-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-621",
+    "rule_id": "vulnhunterx.php.variable-variables",
+    "file_path": "php/variable-variables/clean.php",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "php",
+    "label": "FP",
+    "code_snippet": "<?php\n// Direct assignment, no variable-variables\n$user = $_GET[\"user\"] ?? \"anonymous\";\necho $user;\n",
+    "metadata": {
+      "rule_name": "variable-variables",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-python-flask-debug-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-489",
+    "rule_id": "vulnhunterx.py.flask-debug",
+    "file_path": "python/flask-debug/vuln.py",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "python",
+    "label": "TP",
+    "code_snippet": "# CWE-489: Flask debug mode enabled in production\nfrom flask import Flask\n\napp = Flask(__name__)\n\n\n@app.route(\"/\")\ndef index():\n    return \"ok\"\n\n\nif __name__ == \"__main__\":\n    app.run(host=\"0.0.0.0\", debug=True)\n",
+    "metadata": {
+      "rule_name": "flask-debug",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-python-flask-debug-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-489",
+    "rule_id": "vulnhunterx.py.flask-debug",
+    "file_path": "python/flask-debug/clean.py",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "python",
+    "label": "FP",
+    "code_snippet": "# Debug disabled \u2014 safe for production\nfrom flask import Flask\n\napp = Flask(__name__)\n\n\n@app.route(\"/\")\ndef index():\n    return \"ok\"\n\n\nif __name__ == \"__main__\":\n    app.run(host=\"0.0.0.0\", debug=False)\n",
+    "metadata": {
+      "rule_name": "flask-debug",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-python-insecure-tls-context-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-295",
+    "rule_id": "vulnhunterx.py.insecure-tls-context",
+    "file_path": "python/insecure-tls-context/vuln.py",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "python",
+    "label": "TP",
+    "code_snippet": "# CWE-295: SSLContext with verification disabled\nimport ssl\n\nctx = ssl.create_default_context()\nctx.check_hostname = False\nctx.verify_mode = ssl.CERT_NONE\n",
+    "metadata": {
+      "rule_name": "insecure-tls-context",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-python-insecure-tls-context-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-295",
+    "rule_id": "vulnhunterx.py.insecure-tls-context",
+    "file_path": "python/insecure-tls-context/clean.py",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "python",
+    "label": "FP",
+    "code_snippet": "# Default-secure context \u2014 safe\nimport ssl\n\nctx = ssl.create_default_context()\n# check_hostname and CERT_REQUIRED are the defaults \u2014 don't disable them\n",
+    "metadata": {
+      "rule_name": "insecure-tls-context",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-python-regex-injection-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-1333",
+    "rule_id": "vulnhunterx.py.regex-injection",
+    "file_path": "python/regex-injection/vuln.py",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "python",
+    "label": "TP",
+    "code_snippet": "# CWE-1333: user input compiled as a regex directly\nimport re\nfrom flask import request\n\n\ndef search():\n    re.compile(request.args.get(\"pattern\", \"\"))\n    return \"ok\"\n",
+    "metadata": {
+      "rule_name": "regex-injection",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-python-regex-injection-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-1333",
+    "rule_id": "vulnhunterx.py.regex-injection",
+    "file_path": "python/regex-injection/clean.py",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "python",
+    "label": "FP",
+    "code_snippet": "# re.escape \u2014 input treated as a literal substring, not a pattern\nimport re\nfrom flask import request\n\n\ndef search():\n    raw = request.args.get(\"pattern\", \"\")\n    pattern = re.compile(re.escape(raw))\n    return \"ok\"\n",
+    "metadata": {
+      "rule_name": "regex-injection",
+      "variant": "clean"
+    }
+  },
+  {
+    "id": "secrule-python-unsafe-yaml-vuln",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-502",
+    "rule_id": "vulnhunterx.py.unsafe-yaml",
+    "file_path": "python/unsafe-yaml/vuln.py",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "python",
+    "label": "TP",
+    "code_snippet": "# CWE-502: yaml.load without SafeLoader\nimport yaml\n\n\ndef load_config(path: str):\n    with open(path) as f:\n        return yaml.load(f)\n",
+    "metadata": {
+      "rule_name": "unsafe-yaml",
+      "variant": "vuln"
+    }
+  },
+  {
+    "id": "secrule-python-unsafe-yaml-clean",
+    "source_dataset": "security-rules",
+    "cwe_id": "CWE-502",
+    "rule_id": "vulnhunterx.py.unsafe-yaml",
+    "file_path": "python/unsafe-yaml/clean.py",
+    "function_name": "",
+    "start_line": 1,
+    "lang": "python",
+    "label": "FP",
+    "code_snippet": "# SafeLoader \u2014 only loads YAML primitive types\nimport yaml\n\n\ndef load_config(path: str):\n    with open(path) as f:\n        return yaml.safe_load(f)\n",
+    "metadata": {
+      "rule_name": "unsafe-yaml",
+      "variant": "clean"
+    }
+  }
+]

--- a/benchmarks/metrics/cost.py
+++ b/benchmarks/metrics/cost.py
@@ -115,6 +115,11 @@ DEFAULT_PRICING: dict[str, Pricing] = {
     "gpt-4.1":           Pricing(2.00, 8.00,  input_cache_hit_per_million=0.50),
     "gpt-4.1-mini":      Pricing(0.40, 1.60,  input_cache_hit_per_million=0.10),
     "gpt-4.1-nano":      Pricing(0.10, 0.40,  input_cache_hit_per_million=0.025),
+    # GPT-5 family — OpenAI public pricing (snapshot 2026-01). Cache-hit
+    # input billed at 10% of cache-miss.
+    "gpt-5":             Pricing(1.25, 10.00, input_cache_hit_per_million=0.125),
+    "gpt-5-mini":        Pricing(0.25, 2.00,  input_cache_hit_per_million=0.025),
+    "gpt-5-nano":        Pricing(0.05, 0.40,  input_cache_hit_per_million=0.005),
     # Reasoning models — list pricing as of 2026-01 snapshot.
     "o1":                Pricing(15.00, 60.00, input_cache_hit_per_million=7.50),
     "o3":                Pricing(2.00, 8.00,  input_cache_hit_per_million=0.50),
@@ -215,6 +220,37 @@ def resolve_pricing(
     return None
 
 
+# Models served locally or via Ollama incur no per-token API cost, so their
+# imputed cost is $0 rather than "unknown". Matched by prefix on the LiteLLM
+# id (``ollama/...``, ``ollama_chat/...``) so the model-matrix cost column and
+# the cost-vs-F1 frontier plot local models at zero instead of dropping them.
+_LOCAL_PROVIDER_PREFIXES = ("ollama/", "ollama_chat/")
+_ZERO_PRICING = Pricing(0.0, 0.0, input_cache_hit_per_million=0.0)
+
+
+def auto_pricing(
+    model: str,
+    schedule: dict[str, Pricing] | Pricing | None = None,
+) -> Pricing | None:
+    """Resolve a ``Pricing`` for ``model`` with sensible defaults.
+
+    - ``schedule`` defaults to ``DEFAULT_PRICING`` (covers GPT, DeepSeek,
+      Qwen, Claude) so callers need not pass ``--pricing`` for known models.
+    - Local / Ollama models (``ollama/...``) resolve to a zero-cost
+      ``Pricing`` so their imputed cost is $0, not ``None``.
+    - Returns ``None`` only for an unknown *paid* model — the honest signal
+      that a pricing entry is missing.
+    """
+    if schedule is None:
+        schedule = DEFAULT_PRICING
+    hit = resolve_pricing(schedule, model)
+    if hit is not None:
+        return hit
+    if model.startswith(_LOCAL_PROVIDER_PREFIXES):
+        return _ZERO_PRICING
+    return None
+
+
 def imputed_cost(
     input_tokens: int,
     output_tokens: int,
@@ -229,8 +265,11 @@ def imputed_cost(
     no ``input_cache_hit_per_million`` set, this argument is ignored
     (cached tokens are billed at the regular input rate, preserving
     back-compat).
+
+    Local / Ollama models resolve to $0 (via ``auto_pricing``) rather than
+    ``None``; ``None`` is returned only for an unknown *paid* model.
     """
-    p = resolve_pricing(schedule, model)
+    p = auto_pricing(model, schedule)
     if p is None:
         return None
     return p.cost(input_tokens, output_tokens, input_cached_tokens=input_cached_tokens)

--- a/benchmarks/metrics/evaluator.py
+++ b/benchmarks/metrics/evaluator.py
@@ -31,7 +31,6 @@ from benchmarks.metrics.stats import (
     wilson_ci,
 )
 
-
 # Markers that an ERROR verdict came from an LLM-API failure (rate-limit, quota,
 # network) rather than a model decision. Used to separate operational misses
 # from genuine model errors when reporting per-pair metrics.

--- a/benchmarks/metrics/stats.py
+++ b/benchmarks/metrics/stats.py
@@ -25,9 +25,8 @@ from __future__ import annotations
 
 import math
 import random
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Callable
 
 # ---- Wilson CI ------------------------------------------------------------
 

--- a/benchmarks/scripts/compare_models.py
+++ b/benchmarks/scripts/compare_models.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 VinSOC Cyber
+
+"""Aggregate a model-matrix run into one side-by-side comparison.
+
+Reads ``matrix.json`` (written by ``run_model_matrix.py``) from a matrix
+directory, loads each member model's ``summary.json`` using the same loaders as
+``generate_report.py``, and writes ``COMPARISON.md`` — one row per
+(model × dataset × approach) with precision / recall / F1 / FP-reduction /
+NMD-rate / tokens-per-finding / p95 latency / cost.
+
+Cost note: for local / Ollama models the real API cost is $0; the imputed cost
+(tokens × list price, where available) is shown so the cost-vs-F1 frontier
+doesn't plot them misleadingly.
+
+Examples:
+    python benchmarks/scripts/compare_models.py --run-dir benchmarks/results/matrix_20260530_101500
+    python benchmarks/scripts/compare_models.py --run-dir <matrix_dir> --charts
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from benchmarks.scripts.generate_report import _load_results, _load_run_meta  # noqa: E402
+
+
+def _pct(v: float | None) -> str:
+    return "—" if v is None else f"{v * 100:.1f}%"
+
+
+def _num(v: float | int | None, dec: int = 1) -> str:
+    return "—" if v is None else f"{v:.{dec}f}"
+
+
+def _member_cost(summaries: list[dict]) -> tuple[float, float | None]:
+    """Return (real_cost, imputed_cost_or_None) summed across a member's rows."""
+    real = sum(s.get("total_cost_usd", 0.0) or 0.0 for s in summaries)
+    imp = [s.get("imputed_api_cost_usd") for s in summaries
+           if s.get("imputed_api_cost_usd") is not None]
+    return real, (sum(imp) if imp else None)
+
+
+def _cost_str(real: float, imputed: float | None) -> str:
+    if imputed is not None and (real == 0.0 or imputed > real):
+        return f"${real:.4f} (imp ${imputed:.4f})"
+    return f"${real:.4f}"
+
+
+def build_comparison(matrix_dir: Path) -> str:
+    manifest_path = matrix_dir / "matrix.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"matrix.json not found in {matrix_dir}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    members = manifest.get("members", [])
+
+    rows: list[dict] = []
+    failed: list[str] = []
+    for member in members:
+        mid = member["model_id"]
+        if member.get("returncode", 0) != 0:
+            failed.append(f"{mid} (exit {member['returncode']})")
+        member_dir = matrix_dir / member.get("subdir", mid)
+        if not member_dir.is_dir():
+            continue
+        summaries = _load_results(member_dir)
+        meta = _load_run_meta(member_dir)
+        real, imputed = _member_cost(summaries)
+        model_label = meta.get("model", member.get("model", mid))
+        for s in summaries:
+            rows.append({
+                "model_id": mid,
+                "model": model_label,
+                "provider": member.get("provider", meta.get("provider", "")),
+                "dataset": s.get("dataset", "?"),
+                "approach": s.get("approach", "?"),
+                "precision": s.get("precision"),
+                "recall": s.get("recall"),
+                "f1": s.get("f1"),
+                "fp_reduction_rate": s.get("fp_reduction_rate"),
+                "nmd_rate": s.get("nmd_rate"),
+                "tokens_per_finding": s.get("tokens_per_finding"),
+                "p95_latency_s": s.get("p95_latency_s"),
+                "cost": _cost_str(*_member_cost([s])),
+            })
+
+    rows.sort(key=lambda r: (r["dataset"], r["approach"], -(r["f1"] or 0.0)))
+
+    out: list[str] = ["# Model Comparison", ""]
+    out.append(f"Matrix dir: `{matrix_dir}`  ")
+    out.append(f"Datasets: {', '.join(manifest.get('datasets', []))} · "
+               f"Approaches: {', '.join(manifest.get('approaches', []))} · "
+               f"limit: {manifest.get('limit', 0)}"
+               f"{' · *(dry-run)*' if manifest.get('dry_run') else ''}")
+    out.append("")
+    if failed:
+        out.append(f"> ⚠️ Member run(s) failed: {', '.join(failed)}. "
+                   "Their rows may be missing or partial.")
+        out.append("")
+
+    out.append("| Model | Dataset | Approach | Precision | Recall | F1 | "
+               "FP-Reduction | NMD | Tok/Find | p95 s | Cost |")
+    out.append("| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |")
+    for r in rows:
+        out.append(
+            f"| {r['model_id']} | {r['dataset']} | {r['approach']} | "
+            f"{_pct(r['precision'])} | {_pct(r['recall'])} | {_pct(r['f1'])} | "
+            f"{_pct(r['fp_reduction_rate'])} | {_pct(r['nmd_rate'])} | "
+            f"{_num(r['tokens_per_finding'], 0)} | {_num(r['p95_latency_s'], 2)} | "
+            f"{r['cost']} |"
+        )
+    out.append("")
+    out.append("_Cost shows real API cost; `(imp $…)` is the imputed "
+               "tokens×list-price estimate (used for local/Ollama, billed $0)._")
+    return "\n".join(out) + "\n"
+
+
+def _render_charts(matrix_dir: Path) -> None:
+    """F1-by-model bar + cost-vs-F1 scatter. No-op if matplotlib is absent."""
+    try:
+        import matplotlib  # noqa: PLC0415
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt  # noqa: PLC0415
+    except ImportError:
+        print("matplotlib not installed — skipping charts "
+              "(install with `uv pip install -e \".[benchmark]\"`).", file=sys.stderr)
+        return
+
+    manifest = json.loads((matrix_dir / "matrix.json").read_text(encoding="utf-8"))
+    labels, f1s, costs = [], [], []
+    for member in manifest.get("members", []):
+        member_dir = matrix_dir / member.get("subdir", member["model_id"])
+        if not member_dir.is_dir():
+            continue
+        summaries = _load_results(member_dir)
+        # Mean F1 across that member's non-baseline rows.
+        f1_vals = [s.get("f1") for s in summaries
+                   if s.get("approach") != "raw-sast" and s.get("f1") is not None]
+        if not f1_vals:
+            continue
+        real, imputed = _member_cost(summaries)
+        labels.append(member["model_id"])
+        f1s.append(sum(f1_vals) / len(f1_vals))
+        costs.append(imputed if (real == 0.0 and imputed is not None) else real)
+
+    if not labels:
+        print("No scored members — skipping charts.", file=sys.stderr)
+        return
+
+    fig, ax = plt.subplots(figsize=(max(6, len(labels) * 1.2), 4))
+    ax.bar(labels, [f * 100 for f in f1s], color="#4c72b0")
+    ax.set_ylabel("Mean F1 (%)")
+    ax.set_title("F1 by model")
+    ax.set_ylim(0, 100)
+    plt.xticks(rotation=30, ha="right")
+    fig.tight_layout()
+    fig.savefig(matrix_dir / "f1_by_model.png", dpi=120)
+    plt.close(fig)
+
+    fig, ax = plt.subplots(figsize=(6, 5))
+    ax.scatter(costs, [f * 100 for f in f1s], color="#dd8452")
+    for x, y, lab in zip(costs, f1s, labels, strict=False):
+        ax.annotate(lab, (x, y * 100), fontsize=8, xytext=(4, 4),
+                    textcoords="offset points")
+    ax.set_xlabel("Cost (USD, real or imputed)")
+    ax.set_ylabel("Mean F1 (%)")
+    ax.set_title("Cost vs F1 frontier")
+    fig.tight_layout()
+    fig.savefig(matrix_dir / "cost_vs_f1.png", dpi=120)
+    plt.close(fig)
+    print(f"Charts written to {matrix_dir}", file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Aggregate a model-matrix run.")
+    parser.add_argument("--run-dir", type=Path, required=True,
+                        help="Matrix parent directory containing matrix.json.")
+    parser.add_argument("--charts", action="store_true",
+                        help="Also render F1-by-model and cost-vs-F1 charts.")
+    args = parser.parse_args()
+
+    try:
+        report = build_comparison(args.run_dir)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    out_path = args.run_dir / "COMPARISON.md"
+    out_path.write_text(report, encoding="utf-8")
+    print(f"✓ COMPARISON.md written: {out_path}", file=sys.stderr)
+    if args.charts:
+        _render_charts(args.run_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/scripts/generate_report.py
+++ b/benchmarks/scripts/generate_report.py
@@ -423,6 +423,17 @@ def _key_findings(
     return "\n".join(lines)
 
 
+# Function-level *detection* datasets (whole-function vuln labels, no real SAST
+# alert). They are NOT finding-level FP-reduction sets: their precision/FP-
+# reduction numbers are not comparable to Track-1 and should be read as
+# recall/TP-preservation on noisy CVE labels only. See benchmarks/RESEARCH.md §6.
+_DETECTION_TRACK_DATASETS = {"diversevul", "cvefixes", "primevul", "bigvul", "devign"}
+
+
+def _is_detection_track(dataset: str) -> bool:
+    return (dataset or "").lower() in _DETECTION_TRACK_DATASETS
+
+
 def _main_table(summaries: list[dict]) -> str:
     """Build the main Markdown comparison table."""
     headers = [
@@ -433,10 +444,15 @@ def _main_table(summaries: list[dict]) -> str:
     rows = [headers]
     rows.append(["---"] * len(headers))
 
+    has_detection = any(_is_detection_track(s.get("dataset", "")) for s in summaries)
     for s in summaries:
+        dataset = s.get("dataset", "?")
+        # Mark function-level detection datasets so their numbers aren't read
+        # as finding-level FP-reduction results.
+        dataset_label = f"{dataset} †" if _is_detection_track(dataset) else dataset
         rows.append([
             s.get("approach", "?"),
-            s.get("dataset", "?"),
+            dataset_label,
             _pct(s.get("precision")),
             _pct(s.get("recall")),
             _pct(s.get("effective_recall")),
@@ -450,7 +466,7 @@ def _main_table(summaries: list[dict]) -> str:
         ])
 
     table = "\n".join("| " + " | ".join(r) + " |" for r in rows)
-    explanation = "\n".join([
+    explanation_lines = [
         "> **How to read this table:**",
         "> - **Precision**: Of findings the approach labeled as vulnerabilities, what fraction are truly vulnerable.",
         ">   Higher = fewer false alarms. Target: >80% for LLM approaches.",
@@ -460,8 +476,15 @@ def _main_table(summaries: list[dict]) -> str:
         "> - **FP Reduc.**: How many raw-SAST false positives the approach eliminated. Higher is better.",
         "> - **TP Pres.**: How many raw-SAST true positives the approach kept. Should stay >80%.",
         "> - **NMD Rate**: Fraction of findings where the LLM could not decide. >30% indicates insufficient context.",
-    ])
-    return table + "\n\n" + explanation
+    ]
+    if has_detection:
+        explanation_lines.append(
+            "> - **† Track-2 (detection)**: whole-function vuln-detection datasets "
+            "(no real SAST alert; ~60% label accuracy). Read Precision/FP-Reduc. "
+            "as recall/TP-preservation only — **not** comparable to finding-level "
+            "FP-reduction. See RESEARCH.md §6."
+        )
+    return table + "\n\n" + "\n".join(explanation_lines)
 
 
 def _calibration_table(summaries: list[dict]) -> str:

--- a/benchmarks/scripts/run_benchmark.py
+++ b/benchmarks/scripts/run_benchmark.py
@@ -13,43 +13,43 @@ Usage examples:
     python benchmarks/scripts/run_benchmark.py \\
         --dataset secllmholmes --approach all --limit 20 --dry-run
 
-    # Real run with GPT-4o-mini (cheapest):
+    # Real run with gpt-4.1 (cost-effective frontier):
     python benchmarks/scripts/run_benchmark.py \\
-        --dataset secllmholmes --approach all --model gpt-4o-mini --limit 50
+        --dataset secllmholmes --approach all --model gpt-4.1 --limit 50
 
     # Full benchmark:
     python benchmarks/scripts/run_benchmark.py \\
-        --dataset all --approach all --model gpt-4o
+        --dataset all --approach all --model gpt-5
 
     # Resumable run — target a named directory, resume after interruption:
     python benchmarks/scripts/run_benchmark.py \\
-        --dataset all --approach all --model gpt-4o \\
+        --dataset all --approach all --model gpt-5 \\
         --run-dir benchmarks/results/my_run
     # ... Ctrl+C ...
     python benchmarks/scripts/run_benchmark.py \\
-        --dataset all --approach all --model gpt-4o \\
+        --dataset all --approach all --model gpt-5 \\
         --run-dir benchmarks/results/my_run --resume
 
     # Iteration sweep (VulnHunterX at max_iterations=1,2,3):
     python benchmarks/scripts/run_benchmark.py \\
         --dataset secllmholmes --approach vulnhunterx \\
-        --model gpt-4o-mini --iteration-sweep
+        --model gpt-4.1 --iteration-sweep
 """
 
 from __future__ import annotations
 
 import argparse
-import warnings
-from typing import Any
 import json
 import logging
 import os
 import sys
 import threading
 import time
+import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 # Allow running as script without installing the package
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -60,6 +60,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 # Load .env before argparse so LLM_MODEL / LLM_PROVIDER become default values
 from dotenv import load_dotenv  # noqa: E402
+
 load_dotenv(_REPO_ROOT / ".env")
 
 # Load benchmark.yaml defaults (CLI flags override these)
@@ -78,9 +79,6 @@ _DEFAULT_MAX_ITERATIONS: int = (
 
 from benchmarks.adapters.ground_truth import GroundTruthEntry, load_entries  # noqa: E402
 from benchmarks.approaches.base import BenchmarkApproach, BenchmarkResult  # noqa: E402
-from benchmarks.approaches.raw_sast import RawSastApproach  # noqa: E402
-from benchmarks.approaches.ablation import AblationApproach  # noqa: E402
-from benchmarks.approaches.vulnhunterx import VulnHunterXApproach  # noqa: E402
 from benchmarks.metrics.cost import Pricing, load_pricing  # noqa: E402
 from benchmarks.metrics.evaluator import ApproachMetrics, evaluate  # noqa: E402
 from benchmarks.scripts._progress import (  # noqa: E402
@@ -190,6 +188,10 @@ if _MANIFEST_PATH.is_file():
 
 
 def _resolve_dataset_path(name: str) -> Path:
+    if name == "security-rules":
+        # In-repo finding-shaped fixtures (Go/PHP/JS/Python). No download —
+        # the adapter walks the project's own custom-rule vuln/clean pairs.
+        return _REPO_ROOT / "tests" / "fixtures" / "security-rules"
     return DATASETS_DIR / _DATASET_DIRNAMES.get(name, name)
 
 
@@ -740,7 +742,7 @@ def main() -> int:
         metavar="APPROACH",
         help=f"One or more of: {' '.join(_approach_names)} all",
     )
-    parser.add_argument("--model", default=os.environ.get("LLM_MODEL", "gpt-4o"))
+    parser.add_argument("--model", default=os.environ.get("LLM_MODEL", "gpt-4.1"))
     parser.add_argument("--provider", default=os.environ.get("LLM_PROVIDER", "openai"))
     parser.add_argument("--limit", type=int, default=0, help="Cap entries per dataset (0=all)")
     parser.add_argument(

--- a/benchmarks/scripts/run_model_matrix.py
+++ b/benchmarks/scripts/run_model_matrix.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 VinSOC Cyber
+
+"""Run the SAME benchmark across multiple models and collect the results.
+
+The single-model runner (``run_benchmark.py``) evaluates one ``--model`` per
+invocation. This orchestrator reads a model matrix from
+``benchmarks/config/models.yaml`` (or ``--models id1,id2``) and launches one
+``run_benchmark.py`` **subprocess per model** into its own results subdir, then
+writes a ``matrix.json`` manifest. ``compare_models.py`` aggregates the members
+into one side-by-side ``COMPARISON.md``.
+
+Why subprocesses (not in-process): each provider needs an isolated credential
+environment — DeepSeek sets ``OPENAI_BASE_URL`` + ``OPENAI_API_KEY``, plain
+OpenAI must NOT have a base URL, Ollama uses ``OLLAMA_API_*``. These collide in
+one process. A fresh subprocess with a per-model env gives clean isolation and
+reuses 100% of run_benchmark's pricing/preflight/checkpoint/resume logic.
+
+Examples:
+    # Dry-run across the default matrix (no API cost)
+    python benchmarks/scripts/run_model_matrix.py \
+        --dataset secllmholmes --approach vulnhunterx --limit 10 --dry-run
+
+    # Real run across two models on the security-rules dataset
+    python benchmarks/scripts/run_model_matrix.py \
+        --models gpt-4.1,deepseek-chat \
+        --dataset security-rules --approach all
+
+    # Forward dataset-specific flags after `--`
+    python benchmarks/scripts/run_model_matrix.py --dataset juliet -- --juliet-per-cwe 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+from dotenv import dotenv_values
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RUN_BENCHMARK = _REPO_ROOT / "benchmarks" / "scripts" / "run_benchmark.py"
+_MODELS_YAML = _REPO_ROOT / "benchmarks" / "config" / "models.yaml"
+_RESULTS_DIR = _REPO_ROOT / "benchmarks" / "results"
+
+# Credential / provider-selection keys that must be reset per model so a value
+# from the parent shell or repo .env doesn't leak across providers (e.g. a
+# DeepSeek OPENAI_BASE_URL bleeding into a plain-OpenAI run). Set to "" (not
+# deleted) so run_benchmark's ``load_dotenv(override=False)`` treats them as
+# present and does NOT re-inject them from the repo .env.
+_ISOLATED_ENV_KEYS = (
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENAI_API_BASE",
+    "ANTHROPIC_API_KEY",
+    "OLLAMA_API_BASE",
+    "OLLAMA_API_KEYS",
+    "OLLAMA_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "LLM_MODEL",
+    "LLM_PROVIDER",
+)
+
+
+def _load_models(config_path: Path, selected: list[str] | None) -> list[dict]:
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    models = raw.get("models", [])
+    if not isinstance(models, list) or not models:
+        raise ValueError(f"No 'models:' list found in {config_path}")
+    by_id = {}
+    for m in models:
+        if "id" not in m or "model" not in m:
+            raise ValueError(f"Model entry missing 'id'/'model': {m!r}")
+        by_id[m["id"]] = m
+    if selected:
+        missing = [s for s in selected if s not in by_id]
+        if missing:
+            raise ValueError(
+                f"unknown model id(s) {missing}; available: {sorted(by_id)}"
+            )
+        return [by_id[s] for s in selected]
+    return list(models)
+
+
+def _build_env(model: dict) -> dict[str, str]:
+    """Per-model environment: parent env with provider keys reset, then the
+    model's own .env file overlaid."""
+    env = dict(os.environ)
+    for k in _ISOLATED_ENV_KEYS:
+        env[k] = ""  # block repo-.env re-injection (override=False)
+    env_file = model.get("env")
+    if env_file:
+        path = (_REPO_ROOT / env_file).resolve()
+        if not path.is_file():
+            print(f"warning: env file not found for {model['id']}: {path}", file=sys.stderr)
+        else:
+            for key, val in dotenv_values(path).items():
+                if val is not None:
+                    env[key] = val
+    return env
+
+
+def _build_argv(model: dict, subdir: Path, common: list[str], extra: list[str]) -> list[str]:
+    argv = [
+        sys.executable,
+        str(_RUN_BENCHMARK),
+        "--model", str(model["model"]),
+        "--provider", str(model.get("provider", "openai")),
+        "--run-dir", str(subdir),
+        *common,
+        *extra,
+    ]
+    pricing = model.get("pricing")
+    if pricing:
+        argv += ["--pricing", str((_REPO_ROOT / pricing).resolve())]
+    return argv
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run a benchmark across a matrix of models.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--models-config", type=Path, default=_MODELS_YAML,
+                        help=f"Path to models.yaml (default: {_MODELS_YAML}).")
+    parser.add_argument("--models", default=None,
+                        help="Comma-separated model ids to run (default: all in the config).")
+    parser.add_argument("--dataset", default="secllmholmes",
+                        help="Dataset to run (forwarded to run_benchmark). Use a "
+                             "family tag ('owasp') or 'all' for multiple; "
+                             "run the matrix again per dataset for an explicit set.")
+    parser.add_argument("--approach", nargs="+", default=["vulnhunterx"],
+                        help="Approach(es) to run (forwarded to run_benchmark).")
+    parser.add_argument("--limit", type=int, default=0)
+    parser.add_argument("--jobs", "-j", type=int, default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--resume", action="store_true",
+                        help="Resume each member run from its checkpoint.")
+    parser.add_argument("--quiet", action="store_true")
+    parser.add_argument("--run-dir", type=Path, default=None,
+                        help="Matrix parent dir (default: benchmarks/results/matrix_<timestamp>).")
+    parser.add_argument("--continue-on-error", action="store_true",
+                        help="Keep running remaining models if one fails (default: stop).")
+    parser.add_argument("extra", nargs=argparse.REMAINDER,
+                        help="Args after `--` are forwarded verbatim to each run_benchmark.")
+    args = parser.parse_args()
+
+    selected = [s.strip() for s in args.models.split(",")] if args.models else None
+    try:
+        models = _load_models(args.models_config, selected)
+    except (ValueError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    matrix_dir = args.run_dir or (_RESULTS_DIR / f"matrix_{datetime.now():%Y%m%d_%H%M%S}")
+    matrix_dir.mkdir(parents=True, exist_ok=True)
+
+    # Flags shared by every member run.
+    common: list[str] = ["--dataset", args.dataset, "--approach", *args.approach]
+    if args.limit:
+        common += ["--limit", str(args.limit)]
+    if args.jobs is not None:
+        common += ["--jobs", str(args.jobs)]
+    if args.dry_run:
+        common.append("--dry-run")
+    if args.resume:
+        common.append("--resume")
+    if args.quiet:
+        common.append("--quiet")
+
+    # argparse.REMAINDER keeps a leading "--"; strip it.
+    extra = list(args.extra)
+    if extra and extra[0] == "--":
+        extra = extra[1:]
+
+    members: list[dict] = []
+    print(f"▶  Model matrix: {len(models)} model(s) → {matrix_dir}", file=sys.stderr)
+    for model in models:
+        mid = model["id"]
+        subdir = matrix_dir / mid
+        subdir.mkdir(parents=True, exist_ok=True)
+        env = _build_env(model)
+        argv = _build_argv(model, subdir, common, extra)
+        print(f"\n── {mid} ({model.get('provider', 'openai')}/{model['model']}) ──", file=sys.stderr)
+        proc = subprocess.run(argv, env=env)  # noqa: S603 — argv is built from trusted config
+        members.append({
+            "model_id": mid,
+            "provider": model.get("provider", "openai"),
+            "model": model["model"],
+            "tier": model.get("tier"),
+            "subdir": mid,
+            "pricing": model.get("pricing"),
+            "returncode": proc.returncode,
+        })
+        if proc.returncode != 0 and not args.continue_on_error:
+            print(f"error: model {mid} exited {proc.returncode}; stopping "
+                  f"(use --continue-on-error to proceed)", file=sys.stderr)
+            break
+
+    manifest = {
+        "matrix_dir": str(matrix_dir),
+        "datasets": [args.dataset],
+        "approaches": args.approach,
+        "limit": args.limit,
+        "dry_run": args.dry_run,
+        "members": members,
+    }
+    (matrix_dir / "matrix.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(f"\n✓ matrix.json written: {matrix_dir / 'matrix.json'}", file=sys.stderr)
+    print(f"  Next: python benchmarks/scripts/compare_models.py --run-dir {matrix_dir}",
+          file=sys.stderr)
+
+    failed = [m["model_id"] for m in members if m["returncode"] != 0]
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/scripts/setup_datasets.py
+++ b/benchmarks/scripts/setup_datasets.py
@@ -119,6 +119,9 @@ def setup_dataset(name: str) -> bool:
             _download_and_extract(cfg["url"], cfg["target_dir"])
         elif cfg["type"] == "gdrive":
             _download_gdrive(cfg["gdrive_id"], cfg["filename"], cfg["target_dir"])
+        elif cfg["type"] == "builtin":
+            logger.info("✓ %s is in-repo (no download needed)", name)
+            return True
         else:
             logger.error("Unknown dataset type: %s", cfg["type"])
             return False

--- a/tests/test_benchmark_adapters.py
+++ b/tests/test_benchmark_adapters.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import json
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -25,7 +24,6 @@ from benchmarks.adapters.ground_truth import (
     load_entries,
     save_entries,
 )
-
 
 # ── GroundTruthEntry ──────────────────────────────────────────────────────────
 
@@ -379,3 +377,85 @@ class TestDiverseVulAdapter:
         entries = DiverseVulAdapter(tmp_path).load(include_unknown_cwe=True)
         assert len(entries) == 3
         assert sum(1 for e in entries if e.cwe_id == "Unknown") == 1
+
+
+class TestSecurityRulesAdapter:
+    def test_loads_in_repo_fixtures_as_tp_fp_pairs(self):
+        from benchmarks.adapters.security_rules_adapter import SecurityRulesAdapter
+
+        # Nonexistent path -> adapter falls back to the in-repo fixtures dir.
+        entries = SecurityRulesAdapter(Path("benchmarks/datasets/security-rules")).load()
+        assert len(entries) > 0
+        tp = [e for e in entries if e.label == LABEL_TP]
+        fp = [e for e in entries if e.label == LABEL_FP]
+        # vuln/clean pairs -> balanced TP/FP.
+        assert len(tp) == len(fp)
+        # Every entry carries a rule_id so it clears the quality gate.
+        assert all(e.rule_id for e in entries)
+
+    def test_rule_id_and_cwe_resolution(self):
+        from benchmarks.adapters.security_rules_adapter import SecurityRulesAdapter
+
+        entries = SecurityRulesAdapter(Path("nonexistent")).load()
+        by_id = {e.id: e for e in entries}
+        # Go goroutine-leak maps to the semgrep custom rule + its CWE.
+        leak = by_id.get("secrule-go-goroutine-leak-vuln")
+        assert leak is not None
+        assert leak.rule_id == "vulnhunterx.go.goroutine-leak"
+        assert leak.cwe_id == "CWE-405"
+        assert leak.lang == "go"
+
+    def test_langs_filter(self):
+        from benchmarks.adapters.security_rules_adapter import SecurityRulesAdapter
+
+        entries = SecurityRulesAdapter(Path("nonexistent")).load(langs=["php"])
+        assert entries
+        assert {e.lang for e in entries} == {"php"}
+
+    def test_limit(self):
+        from benchmarks.adapters.security_rules_adapter import SecurityRulesAdapter
+
+        entries = SecurityRulesAdapter(Path("nonexistent")).load(limit=3)
+        assert len(entries) == 3
+
+
+class TestOpenVulnAdapter:
+    @staticmethod
+    def _write_dataset(tmp_path: Path) -> Path:
+        base = tmp_path / "OpenVuln"
+        (base / "code-context" / "baseline" / "proj").mkdir(parents=True)
+        (base / "ground_truth.csv").write_text(
+            "project_slug,alert_number,cve_id,filename,is_vulnerable\n"
+            "proj,1,CVE-2016-9177,vulnerability_java_path-injection_1.txt,True\n"
+            "proj,2,CVE-2016-9177,vulnerability_java_path-injection_2.txt,False\n"
+        )
+        (base / "Projects_info.csv").write_text(
+            "project_slug,cve_id,cwe_id,cwe_name\n"
+            "proj,CVE-2016-9177,CWE-022,Path Traversal\n"
+        )
+        (base / "code-context" / "baseline" / "proj"
+         / "vulnerability_java_path-injection_1.txt").write_text("File f = new File(p);")
+        return tmp_path
+
+    def test_parses_ground_truth_labels_and_cwe(self, tmp_path):
+        from benchmarks.adapters.openvuln_adapter import OpenVulnAdapter
+
+        self._write_dataset(tmp_path)
+        entries = OpenVulnAdapter(tmp_path).load()
+        assert len(entries) == 2
+        labels = {e.metadata["alert_number"]: e.label for e in entries}
+        assert labels["1"] == LABEL_TP
+        assert labels["2"] == LABEL_FP
+        # CWE-022 normalized to CWE-22; rule_id derived from filename.
+        assert all(e.cwe_id == "CWE-22" for e in entries)
+        assert all(e.rule_id == "java/path-injection" for e in entries)
+
+    def test_snippet_found_and_missing(self, tmp_path):
+        from benchmarks.adapters.openvuln_adapter import OpenVulnAdapter
+
+        self._write_dataset(tmp_path)
+        entries = OpenVulnAdapter(tmp_path).load()
+        by_alert = {e.metadata["alert_number"]: e for e in entries}
+        assert by_alert["1"].code_snippet  # snippet present
+        assert by_alert["1"].metadata["snippet_kind"] == "code-context"
+        assert by_alert["2"].metadata["snippet_kind"] == "missing"

--- a/tests/test_benchmark_cost.py
+++ b/tests/test_benchmark_cost.py
@@ -256,3 +256,32 @@ def test_pricing_cache_hit_clamps_cached_to_input():
     # Claim 2M cached but only 1M input -> clamp to 1M cached, 0 uncached.
     cost = p.cost(1_000_000, 0, input_cached_tokens=2_000_000)
     assert math.isclose(cost, 0.1)
+
+
+class TestAutoPricing:
+    def test_known_paid_models_resolve(self):
+        from benchmarks.metrics.cost import auto_pricing
+
+        assert auto_pricing("gpt-4.1") is not None
+        assert auto_pricing("gpt-5") is not None
+        assert auto_pricing("deepseek-chat") is not None
+        assert auto_pricing("deepseek-reasoner") is not None
+
+    def test_ollama_models_are_zero_cost(self):
+        from benchmarks.metrics.cost import auto_pricing
+
+        p = auto_pricing("ollama/qwen3-coder:480b-cloud")
+        assert p is not None
+        assert p.input_per_million == 0.0
+        assert p.output_per_million == 0.0
+
+    def test_unknown_paid_model_returns_none(self):
+        from benchmarks.metrics.cost import auto_pricing
+
+        assert auto_pricing("definitely-not-a-real-model-xyz") is None
+
+    def test_imputed_cost_zero_for_local(self):
+        from benchmarks.metrics.cost import DEFAULT_PRICING, imputed_cost
+
+        c = imputed_cost(1000, 500, DEFAULT_PRICING, "ollama/llama3.2")
+        assert c == 0.0


### PR DESCRIPTION
- Introduced `openvuln_sample.json` and `security-rules_sample.json` to provide sample data for vulnerability and security rule benchmarks.
- Created `compare_models.py` script to aggregate model-matrix results into a side-by-side comparison report.
- Developed `run_model_matrix.py` script to execute benchmarks across multiple models, handling environment isolation and result collection.